### PR TITLE
[TUN-68] Correct RAR5 variable int reading for correct reading values >> 32 bit

### DIFF
--- a/XADMaster.xcodeproj/project.pbxproj
+++ b/XADMaster.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1737C872BD5877C5DFDA3D99 /* XADRAR5ParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1737CCA9B444F0AF0C3A4456 /* XADRAR5ParserTests.m */; };
 		1B06CD13145CFF2A003907F9 /* XADCrunchParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B06CD11145CFF2A003907F9 /* XADCrunchParser.h */; };
 		1B06CD14145CFF2A003907F9 /* XADCrunchParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B06CD11145CFF2A003907F9 /* XADCrunchParser.h */; };
 		1B06CD15145CFF2A003907F9 /* XADCrunchParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B06CD11145CFF2A003907F9 /* XADCrunchParser.h */; };
@@ -1668,6 +1669,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1737CCA9B444F0AF0C3A4456 /* XADRAR5ParserTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XADRAR5ParserTests.m; sourceTree = "<group>"; };
 		1B06CD11145CFF2A003907F9 /* XADCrunchParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XADCrunchParser.h; sourceTree = "<group>"; };
 		1B06CD12145CFF2A003907F9 /* XADCrunchParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XADCrunchParser.m; sourceTree = "<group>"; };
 		1B06CD1A145CFF36003907F9 /* XADCrunchHandles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XADCrunchHandles.h; sourceTree = "<group>"; };
@@ -3368,6 +3370,7 @@
 			children = (
 				73DA3467206B6BF1006ADB42 /* XADPlatformOSXTests.m */,
 				73DA3469206B6BF1006ADB42 /* Info.plist */,
+				1737CCA9B444F0AF0C3A4456 /* XADRAR5ParserTests.m */,
 			);
 			path = XADMasterTests;
 			sourceTree = "<group>";
@@ -5011,6 +5014,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				73DA3468206B6BF1006ADB42 /* XADPlatformOSXTests.m in Sources */,
+				1737C872BD5877C5DFDA3D99 /* XADRAR5ParserTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XADMasterTests/XADRAR5ParserTests.m
+++ b/XADMasterTests/XADRAR5ParserTests.m
@@ -1,0 +1,101 @@
+/*
+ * XADRAR5ParserTests.m
+ *
+ * Copyright (c) 2017-present, MacPaw Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+#import <XCTest/XCTest.h>
+//#import <XADMaster/CSHandle.h>
+#import "../CSHandle.h"
+#import "../CSMemoryHandle.h"
+
+@interface XADRAR5Parser : NSObject
++ (uint64_t)readRAR5VIntFrom:(CSHandle *)handle;
+@end
+
+
+@interface XADRAR5ParserTests : XCTestCase
+
+@end
+
+@implementation XADRAR5ParserTests
+
+- (void)testReadingVariableInt1 {
+    uint8_t buffer[] = {
+        0x01
+    };
+    XADMemoryHandle *handle = [CSMemoryHandle memoryHandleForReadingBuffer:buffer length:sizeof(buffer)];
+    uint64_t vint = [XADRAR5Parser readRAR5VIntFrom:handle];
+    XCTAssertEqual(vint, (uint64_t) 1, @"Variable int should handle 7 bit sequences");
+}
+
+- (void)testReadingVariableInt7bits {
+    uint8_t buffer[] = {
+        0x80 | 0x00,
+        0x01
+    };
+    XADMemoryHandle *handle = [CSMemoryHandle memoryHandleForReadingBuffer:buffer length:sizeof(buffer)];
+    uint64_t vint = [XADRAR5Parser readRAR5VIntFrom:handle];
+    XCTAssertEqual(vint, (uint64_t) 1 << 7, @"Variable int should handle 14 bit sequences");
+}
+
+- (void)testReadingVariableInt21bits {
+    uint8_t buffer[] = {
+        0x80 | 0x00,
+        0x80 | 0x00,
+        0x80 | 0x00,
+        0x01
+    };
+    XADMemoryHandle *handle = [CSMemoryHandle memoryHandleForReadingBuffer:buffer length:sizeof(buffer)];
+    uint64_t vint = [XADRAR5Parser readRAR5VIntFrom:handle];
+    XCTAssertEqual(vint, (uint64_t) 1 << 21, @"Variable int should handle 21 bit sequences");
+}
+
+- (void)testReadingVariableInt35bits {
+    uint8_t buffer[] = {
+        0x80 | 0x00,
+        0x80 | 0x00,
+        0x80 | 0x00,
+        0x80 | 0x00,
+        0x80 | 0x00,
+        0x01
+    };
+    XADMemoryHandle *handle = [CSMemoryHandle memoryHandleForReadingBuffer:buffer length:sizeof(buffer)];
+    uint64_t vint = [XADRAR5Parser readRAR5VIntFrom:handle];
+    XCTAssertEqual(vint, (uint64_t) 1 << 35, @"Variable int should handle 21 bit sequences");
+}
+
+- (void)testReadingVariableInt49bits {
+    uint8_t buffer[] = {
+        0x80 | 0x00,
+        0x80 | 0x00,
+        0x80 | 0x00,
+        0x80 | 0x00,
+        0x80 | 0x00,
+        0x80 | 0x00,
+        0x80 | 0x00,
+        0x01
+    };
+    XADMemoryHandle *handle = [CSMemoryHandle memoryHandleForReadingBuffer:buffer length:sizeof(buffer)];
+    uint64_t vint = [XADRAR5Parser readRAR5VIntFrom:handle];
+    XCTAssertEqual(vint, (uint64_t) 1 << 49, @"Variable int should handle 21 bit sequences");
+}
+
+
+@end
+

--- a/XADRAR5Parser.h
+++ b/XADRAR5Parser.h
@@ -69,3 +69,7 @@ inputParts:(NSArray *)parts isCorrupted:(BOOL)iscorrupted;
 
 @end
 
+@interface XADRAR5Parser(Testing)
++(uint64_t)readRAR5VIntFrom:(CSHandle *)handle;
+@end
+

--- a/XADRAR5Parser.m
+++ b/XADRAR5Parser.m
@@ -45,7 +45,8 @@ static uint64_t ReadRAR5VInt(CSHandle *handle)
 	{
 		uint8_t byte=[handle readUInt8];
 
-		res|=(byte&0x7f)<<pos;
+		uint64_t meaningfulBits = (uint64_t) (byte & 0x7f);
+		res |= meaningfulBits << pos;
 
 		if(!(byte&0x80)) return res;
 
@@ -808,3 +809,13 @@ static uint32_t EncryptRAR5CRC32(uint32_t crc,id context)
 
 	return newcrc^0xffffffff;
 }
+
+
+@implementation XADRAR5Parser(Testing)
+
++(uint64_t)readRAR5VIntFrom:(CSHandle *)handle
+{
+	return ReadRAR5VInt(handle);
+}
+
+@end


### PR DESCRIPTION
Here's an actual change
https://github.com/MacPaw/XADMaster/compare/feature/speed-up-xattr-osx...fix/rar-files-formats?expand=1#diff-90d22276ec7ad764b5c9be6ca217154cL48
```
   res|=(byte&0x7f)<<pos;
vs
  uint64_t meaningfulBits = (uint64_t) (byte & 0x7f);
  res |= meaningfulBits << pos;
```

So here was the issue:
```
byte   // uint_8
byte & 0x7f . // int
(byte&0x7f)<<pos // int . (shoud be uint64).
```

This issue was happening on the values >> 2^31