### PR TITLE
Support WARC 1.0 compliant WARC-Target-URI fields

### DIFF
--- a/XADWARCParser.h
+++ b/XADWARCParser.h
@@ -31,6 +31,7 @@
 -(NSMutableDictionary *)parseHTTPHeadersWithHandle:(CSHandle *)handle;
 -(NSArray *)readHTTPHeadersWithHandle:(CSHandle *)handle;
 
+-(NSString *)getTargetURI:(NSDictionary *)record;
 -(NSArray *)pathComponentsForURLString:(NSString *)urlstring;
 -(NSMutableDictionary *)insertDirectory:(NSString *)name inDirectory:(NSMutableDictionary *)dir;
 -(void)insertFile:(NSString *)name record:(NSMutableDictionary *)record inDirectory:(NSMutableDictionary *)dir;

--- a/XADWARCParser.m
+++ b/XADWARCParser.m
@@ -117,8 +117,7 @@
 		if([type isEqual:@"response"])
 		if([status matchedByPattern:@"^HTTP/[0-9]+\\.[0-9]+ 200"])
 		{
-			NSString *target=[record objectForKey:@"WARC-Target-URI"];
-
+			NSString *target=[self getTargetURI:record];
 			NSArray *components=[self pathComponentsForURLString:target];
 			if(components)
 			{
@@ -148,7 +147,7 @@
 	enumerator=[filerecords objectEnumerator];
 	while((record=[enumerator nextObject]))
 	{
-		NSString *target=[record objectForKey:@"WARC-Target-URI"];
+		NSString *target=[self getTargetURI:record];
 		NSNumber *startnum=[record objectForKey:@"HTTPBodyStart"];
 		NSNumber *endnum=[record objectForKey:@"EndOfRecord"];
 		NSArray *responseheaders=[record objectForKey:@"HTTPHeaders"];
@@ -228,8 +227,24 @@
 	}
 }
 
+-(NSString *)getTargetURI:(NSDictionary *)record
+{
 
+	NSString *target=[record objectForKey:@"WARC-Target-URI"];
 
+	// WARC 1.0 requires WARC-Target-URI to be surrounded by angle brackets,
+	// but most tools don't respect this requirement, so we just strip them
+	// if they're present.
+	//
+	// Read <https://github.com/iipc/warc-specifications/issues/23> for more
+	// details.
+	if(target.length>=2 && [target characterAtIndex:0]=='<' && [target characterAtIndex:target.length-1]=='>')
+	{
+		target=[target substringWithRange:NSMakeRange(1, target.length-2)];
+	}
+
+	return target;
+}
 
 -(NSArray *)pathComponentsForURLString:(NSString *)urlstring
 {


### PR DESCRIPTION
Due to an error in the spec, most implementations of WARC 1.0 don't surround the contents of the `WARC-Target-URI` field with angle brackets even though they're required to do so. There are some tools that do respect this requirement, such as newer versions of GNU Wget. Since both variants are in use, it's best to just strip angle brackets when they're present.

Reference: https://github.com/iipc/warc-specifications/issues/23

Without this patch, WARC files with `WARC-Target-URI` fields surrounded with angle brackets cannot be extracted:

    2018-10-17 20:29:39.071 lsar[8874:8874] Failed to parse URL "<https://example.com/index.html>"