### PR TITLE
Support extracting warc.{gz,bz2,lzma,xz,Z} files directly

### DIFF
--- a/XADBzip2Parser.m
+++ b/XADBzip2Parser.m
@@ -57,7 +57,7 @@
 		[self XADStringWithString:@"Bzip2"],XADCompressionNameKey,
 	nil];
 
-	if([contentname matchedByPattern:@"\\.(tar|cpio|pax)$" options:REG_ICASE])
+	if([contentname matchedByPattern:@"\\.(tar|cpio|pax|warc)$" options:REG_ICASE])
 	[dict setObject:[NSNumber numberWithBool:YES] forKey:XADIsArchiveKey];
 
 	off_t filesize=[[self handle] fileSize];

--- a/XADCompressParser.m
+++ b/XADCompressParser.m
@@ -50,7 +50,7 @@
 		[NSNumber numberWithInt:flags],@"CompressFlags",
 	nil];
 
-	if([contentname matchedByPattern:@"\\.(tar|cpio|pax)$" options:REG_ICASE])
+	if([contentname matchedByPattern:@"\\.(tar|cpio|pax|warc)$" options:REG_ICASE])
 	[dict setObject:[NSNumber numberWithBool:YES] forKey:XADIsArchiveKey];
 
 	off_t size=[[self handle] fileSize];

--- a/XADGzipParser.m
+++ b/XADGzipParser.m
@@ -102,7 +102,7 @@
 
 	if(time) [dict setObject:[NSDate dateWithTimeIntervalSince1970:time] forKey:XADLastModificationDateKey];
 
-	if([contentname matchedByPattern:@"\\.(tar|cpio|pax)$" options:REG_ICASE])
+	if([contentname matchedByPattern:@"\\.(tar|cpio|pax|warc)$" options:REG_ICASE])
 	[dict setObject:[NSNumber numberWithBool:YES] forKey:XADIsArchiveKey];
 
 	off_t filesize=[handle fileSize];

--- a/XADLZMAAloneParser.m
+++ b/XADLZMAAloneParser.m
@@ -74,7 +74,7 @@
 		props,@"LZMAProperties",
 	nil];
 
-	if([contentname matchedByPattern:@"\\.(tar|cpio|pax)$" options:REG_ICASE])
+	if([contentname matchedByPattern:@"\\.(tar|cpio|pax|warc)$" options:REG_ICASE])
 	[dict setObject:[NSNumber numberWithBool:YES] forKey:XADIsArchiveKey];
 
 	uint64_t size=[handle readUInt64LE];

--- a/XADSimpleUnarchiver.m
+++ b/XADSimpleUnarchiver.m
@@ -61,7 +61,7 @@
 
 		NSString *name=[archiveparser name];
 		if([name matchedByPattern:
-		@"\\.(part[0-9]+\\.rar|tar\\.gz|tar\\.bz2|tar\\.lzma|tar\\.xz|tar\\.Z|sit\\.hqx)$"
+		@"\\.(part[0-9]+\\.rar|tar\\.gz|tar\\.bz2|tar\\.lzma|tar\\.xz|tar\\.Z|warc\\.gz|warc\\.bz2|warc\\.lzma|warc\\.xz|warc\\.Z|sit\\.hqx)$"
 		options:REG_ICASE])
 		{
 			enclosingdir=[[[name stringByDeletingPathExtension]

--- a/XADXZParser.m
+++ b/XADXZParser.m
@@ -50,7 +50,7 @@
 		[self XADStringWithString:@"LZMA2"],XADCompressionNameKey,
 	nil];
 
-	if([contentname matchedByPattern:@"\\.(tar|cpio|pax)$" options:REG_ICASE])
+	if([contentname matchedByPattern:@"\\.(tar|cpio|pax|warc)$" options:REG_ICASE])
 	[dict setObject:[NSNumber numberWithBool:YES] forKey:XADIsArchiveKey];
 
 	off_t filesize=[[self handle] fileSize];


### PR DESCRIPTION
This patch enables the user to extract contents of `warc.gz` files in in one step, without first having to ungzip the file. Applying gzip compression to WARC files is a common practice, `wget` and many other tools can do it natively and [there are many `warc.gz` files available for download](https://archive.org/search.php?query=%28warc.gz%24%29). WARC files with other compression formats aren’t as common, but I added them anyway for consistency.