### PR TITLE
Do not confuse multiple files as multipart archive

### DIFF
--- a/XADMaster.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/XADMaster.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/XADMaster.xcodeproj/xcshareddata/xcschemes/XADMaster.xcscheme
+++ b/XADMaster.xcodeproj/xcshareddata/xcschemes/XADMaster.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8DC2EF4F0486A6940098B216"
+               BuildableName = "XADMaster.framework"
+               BlueprintName = "XADMaster"
+               ReferencedContainer = "container:XADMaster.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "73DA3464206B6BF1006ADB42"
+               BuildableName = "XADMasterTests.xctest"
+               BlueprintName = "XADMasterTests"
+               ReferencedContainer = "container:XADMaster.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DC2EF4F0486A6940098B216"
+            BuildableName = "XADMaster.framework"
+            BlueprintName = "XADMaster"
+            ReferencedContainer = "container:XADMaster.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DC2EF4F0486A6940098B216"
+            BuildableName = "XADMaster.framework"
+            BlueprintName = "XADMaster"
+            ReferencedContainer = "container:XADMaster.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DC2EF4F0486A6940098B216"
+            BuildableName = "XADMaster.framework"
+            BlueprintName = "XADMaster"
+            ReferencedContainer = "container:XADMaster.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/XADRAR5Parser.h
+++ b/XADRAR5Parser.h
@@ -29,6 +29,32 @@ typedef struct RAR5Block
 	CSHandle *fh;
 } RAR5Block;
 
+typedef enum {
+    RAR5ArchiveFlagsNone                   = 0,
+    RAR5ArchiveFlagsVolume                 = 0x0001, // Volume. Archive is a part of multivolume set.
+    RAR5ArchiveFlagsVolumeNumberPresent    = 0x0002, // Volume number field is present.
+                                                     // This flag is present in all volumes except first.
+    RAR5ArchiveFlagsSolid                  = 0x0004, // Solid archive.
+    RAR5ArchiveFlagsRecoveryRecordPresent  = 0x0008, // Recovery record is present.
+    RAR5ArchiveFlagsLocked                 = 0x0010, // Locked archive.
+} RAR5ArchiveFlags;
+
+typedef enum {
+   RAR5HeaderTypeUnknown    =  0,
+   RAR5HeaderTypeMain       =  1, //   Main archive header.
+   RAR5HeaderTypeFile       =  2, //   File header.
+   RAR5HeaderTypeService    =  3, //   Service header.
+   RAR5HeaderTypeEncryption =  4, //   Archive encryption header.
+   RAR5HeaderTypeEnd        =  5, //   End of archive header.
+} RAR5HeaderType;
+
+typedef struct RAR5HeaderBlock
+{
+    RAR5Block block;
+    RAR5ArchiveFlags archiveFlags;
+} RAR5HeaderBlock;
+
+
 @interface XADRAR5Parser:XADArchiveParser
 {
 	NSData *headerkey;


### PR DESCRIPTION
XAD Master is a bit confused when there are multiple files which looks like multipart, which aren't actually multipart.
Now, it will first try to read first header and then decide whether it needs to search for other parts