### PR TITLE
Choosing best SFX Parser

### DIFF
--- a/CSInputBuffer.h
+++ b/CSInputBuffer.h
@@ -40,7 +40,7 @@ typedef struct CSInputBuffer
 
 CSInputBuffer *CSInputBufferAlloc(CSHandle *parent,int size);
 CSInputBuffer *CSInputBufferAllocWithBuffer(const uint8_t *buffer,int length,off_t startoffs);
-CSInputBuffer *CSInputBufferAllocEmpty();
+CSInputBuffer *CSInputBufferAllocEmpty(void);
 void CSInputBufferFree(CSInputBuffer *self);
 
 void CSInputSetMemoryBuffer(CSInputBuffer *self,uint8_t *buffer,int length,off_t startoffs);

--- a/XADArchiveParser.h
+++ b/XADArchiveParser.h
@@ -121,6 +121,9 @@ extern NSString *XADParserClass;
 +(void)initialize;
 +(Class)archiveParserClassForHandle:(CSHandle *)handle firstBytes:(NSData *)header
 resourceFork:(XADResourceFork *)fork name:(NSString *)name propertiesToAdd:(NSMutableDictionary *)props;
++ (Class)archiveParserFromParsersWithFloatingSignature:(NSArray *)parsers forHandle:(CSHandle *)handle firstBytes:(NSData *)header name:(NSString *)name propertiesToAdd:(NSMutableDictionary *)props;
++ (BOOL)isValidParserClass:(Class)parserClass forHandle:(CSHandle *)handle firstBytes:(NSData *)header name:(NSString *)name propertiesToAdd:(NSMutableDictionary *)props;
+
 +(XADArchiveParser *)archiveParserForHandle:(CSHandle *)handle name:(NSString *)name;
 +(XADArchiveParser *)archiveParserForHandle:(CSHandle *)handle name:(NSString *)name error:(XADError *)errorptr;
 +(XADArchiveParser *)archiveParserForHandle:(CSHandle *)handle resourceFork:(XADResourceFork *)fork name:(NSString *)name;

--- a/XADArchiveParser.h
+++ b/XADArchiveParser.h
@@ -90,6 +90,9 @@ extern NSString *XADVolumesKey;
 extern NSString *XADVolumeScanningFailedKey;
 extern NSString *XADDiskLabelKey;
 
+extern NSString *XADSignatureOffset;
+extern NSString *XADParserClass;
+
 @interface XADArchiveParser:NSObject
 {
 	CSHandle *sourcehandle;
@@ -235,8 +238,6 @@ regex:(XADRegex *)regex firstFileExtension:(NSString *)firstext;
 name:(NSString *)name;
 +(BOOL)recognizeFileWithHandle:(CSHandle *)handle firstBytes:(NSData *)data
 name:(NSString *)name propertiesToAdd:(NSMutableDictionary *)props;
-+(BOOL)recognizeFileWithHandle:(CSHandle *)handle firstBytes:(NSData *)data
-resourceFork:(XADResourceFork *)fork name:(NSString *)name propertiesToAdd:(NSMutableDictionary *)props;
 +(NSArray *)volumesForHandle:(CSHandle *)handle firstBytes:(NSData *)data
 name:(NSString *)name;
 

--- a/XADMaster.xcodeproj/project.pbxproj
+++ b/XADMaster.xcodeproj/project.pbxproj
@@ -1417,6 +1417,7 @@
 		73DA346A206B6BF1006ADB42 /* XADMaster.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* XADMaster.framework */; };
 		E424FB4721CAE11D00E1C950 /* XADArchiveParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E424FB4621CAE11D00E1C950 /* XADArchiveParserTests.m */; };
 		E424FB4E21CAEC0300E1C950 /* XADZipParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E424FB4D21CAEC0300E1C950 /* XADZipParserTests.m */; };
+		E46E6296225DC2DE00D44E0A /* XADSFXDetectionParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E46E6295225DC2DE00D44E0A /* XADSFXDetectionParserTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -2131,6 +2132,7 @@
 		8DC2EF5B0486A6940098B216 /* XADMaster.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XADMaster.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E424FB4621CAE11D00E1C950 /* XADArchiveParserTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XADArchiveParserTests.m; sourceTree = "<group>"; };
 		E424FB4D21CAEC0300E1C950 /* XADZipParserTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XADZipParserTests.m; sourceTree = "<group>"; };
+		E46E6295225DC2DE00D44E0A /* XADSFXDetectionParserTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XADSFXDetectionParserTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3222,6 +3224,7 @@
 				E424FB4621CAE11D00E1C950 /* XADArchiveParserTests.m */,
 				E424FB4D21CAEC0300E1C950 /* XADZipParserTests.m */,
 				7378D98A21CCD04000A4B11F /* CRCCalculationTests.m */,
+				E46E6295225DC2DE00D44E0A /* XADSFXDetectionParserTests.m */,
 			);
 			path = XADMasterTests;
 			sourceTree = "<group>";
@@ -4715,6 +4718,7 @@
 				73DA3468206B6BF1006ADB42 /* XADPlatformOSXTests.m in Sources */,
 				1737C872BD5877C5DFDA3D99 /* XADRAR5ParserTests.m in Sources */,
 				E424FB4E21CAEC0300E1C950 /* XADZipParserTests.m in Sources */,
+				E46E6296225DC2DE00D44E0A /* XADSFXDetectionParserTests.m in Sources */,
 				E424FB4721CAE11D00E1C950 /* XADArchiveParserTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/XADMasterTests/XADRAR5ParserTests.m
+++ b/XADMasterTests/XADRAR5ParserTests.m
@@ -20,7 +20,6 @@
  */
 
 #import <XCTest/XCTest.h>
-//#import <XADMaster/CSHandle.h>
 #import "../CSHandle.h"
 #import "../CSMemoryHandle.h"
 #import "../XADRAR5Parser.h"

--- a/XADMasterTests/XADSFXDetectionParserTests.m
+++ b/XADMasterTests/XADSFXDetectionParserTests.m
@@ -1,0 +1,115 @@
+//
+//  XADSFXDetectionParserTests.m
+//  XADMasterTests
+//
+//  Created by Paul Taykalo on 4/10/19.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "../XADRARParser.h"
+#import "../XADZipSFXParsers.h"
+#import "../XADArchiveParser.h"
+#import "../CSHandle.h"
+#import "../CSMemoryHandle.h"
+
+@interface XADSFXDetectionParserTests : XCTestCase {
+    int fileSize;
+    uint8_t * buffer;
+}
+
+@end
+
+@implementation XADSFXDetectionParserTests
+
+- (void)setUp {
+    [super setUp];
+    fileSize = 0x10000;
+    buffer = malloc(fileSize);
+}
+
+- (void)tearDown {
+    free(buffer);
+    [super tearDown];
+}
+
+- (void)testRARSFXArchiveDetected {
+
+    NSInteger rarSignatureOffset = 1000;
+    [self setupRarSignatureWithOffset:rarSignatureOffset];
+    NSMutableDictionary * propertiestToAdd = [NSMutableDictionary dictionary];
+
+    XADMemoryHandle *handle = [CSMemoryHandle memoryHandleForReadingBuffer:buffer length:fileSize];
+    NSData *header=[handle readDataOfLengthAtMost:fileSize];
+
+    Class clz = [XADArchiveParser archiveParserClassForHandle:handle firstBytes:header resourceFork:nil name:@"" propertiesToAdd:propertiestToAdd];
+    XCTAssertEqualObjects(clz, [XADEmbeddedRARParser class], @"Embedded rar parser should be detected");
+}
+
+- (void)testZipSFXArchiveDetected {
+
+    NSInteger zipSignatureOffset = 2000;
+    [self setupZipSFXSignatureWithOffset:zipSignatureOffset];
+    NSMutableDictionary * propertiestToAdd = [NSMutableDictionary dictionary];
+    XADMemoryHandle *handle = [CSMemoryHandle memoryHandleForReadingBuffer:buffer length:fileSize];
+    NSData *header=[handle readDataOfLengthAtMost:fileSize];
+
+    Class clz = [XADArchiveParser archiveParserClassForHandle:handle firstBytes:header resourceFork:nil name:@"" propertiesToAdd:propertiestToAdd];
+    XCTAssertEqualObjects(clz, [XADZipSFXParser class], @"Embedded rar parser should be detected");
+}
+
+- (void)testZipRarSignatureDetectedAsZip {
+    [self setupZipSFXSignatureWithOffset: 5000];
+    [self setupRarSignatureWithOffset   :10000];
+
+    NSMutableDictionary * propertiestToAdd = [NSMutableDictionary dictionary];
+    XADMemoryHandle *handle = [CSMemoryHandle memoryHandleForReadingBuffer:buffer length:fileSize];
+    NSData *header=[handle readDataOfLengthAtMost:fileSize];
+
+    Class clz = [XADArchiveParser archiveParserClassForHandle:handle firstBytes:header resourceFork:nil name:@"" propertiesToAdd:propertiestToAdd];
+    XCTAssertEqualObjects(clz, [XADZipSFXParser class], @"Embedded rar parser should be detected");
+}
+
+- (void)testRarZipSignatureDetectedAsRar {
+    [self setupRarSignatureWithOffset   : 5000];
+    [self setupZipSFXSignatureWithOffset:10000];
+
+    NSMutableDictionary * propertiestToAdd = [NSMutableDictionary dictionary];
+    XADMemoryHandle *handle = [CSMemoryHandle memoryHandleForReadingBuffer:buffer length:fileSize];
+    NSData *header=[handle readDataOfLengthAtMost:fileSize];
+
+    Class clz = [XADArchiveParser archiveParserClassForHandle:handle firstBytes:header resourceFork:nil name:@"" propertiesToAdd:propertiestToAdd];
+    XCTAssertEqualObjects(clz, [XADEmbeddedRARParser class], @"Embedded rar parser should be detected");
+}
+
+
+- (void)setupRarSignatureWithOffset:(NSInteger)offset {
+    buffer[offset + 0] = 'R';
+    buffer[offset + 1] = 'a';
+    buffer[offset + 2] = 'r';
+    buffer[offset + 3] = '!';
+    buffer[offset + 4] = 0x1a;
+    buffer[offset + 5] = 0x07;
+    buffer[offset + 6] = 0x00;
+
+}
+
+- (void)setupZipSFXSignatureWithOffset:(NSInteger)offset {
+
+    // MZ :) Long time no see
+    buffer[0] = 0x4d;
+    buffer[1] = 0x5a;
+
+
+    buffer[offset + 0] = 'P';
+    buffer[offset + 1] = 'K';
+    buffer[offset + 2] = 3;
+    buffer[offset + 3] = 4;
+    buffer[offset + 4] = 11;  // > 10 && M 40
+    // ...
+    buffer[offset + 9] = 0x00;
+}
+
+
+
+@end

--- a/XADRARParser.m
+++ b/XADRARParser.m
@@ -834,7 +834,7 @@ name:(NSString *)name propertiesToAdd:(NSMutableDictionary *)props
 	if(header)
 	{
 		[props setObject:[NSNumber numberWithLongLong:header-bytes] forKey:@"RAREmbedOffset"];
-        [props setObject:[NSNumber numberWithLongLong:header-bytes] forKey:@"FoundSignatureOffset"];
+        [props setObject:[NSNumber numberWithLongLong:header-bytes] forKey:XADSignatureOffset];
 		return YES;
 	}
 

--- a/XADRARParser.m
+++ b/XADRARParser.m
@@ -834,6 +834,7 @@ name:(NSString *)name propertiesToAdd:(NSMutableDictionary *)props
 	if(header)
 	{
 		[props setObject:[NSNumber numberWithLongLong:header-bytes] forKey:@"RAREmbedOffset"];
+        [props setObject:[NSNumber numberWithLongLong:header-bytes] forKey:@"FoundSignatureOffset"];
 		return YES;
 	}
 

--- a/XADZipSFXParsers.h
+++ b/XADZipSFXParsers.h
@@ -25,7 +25,7 @@
 }
 
 +(int)requiredHeaderSize;
-+(BOOL)recognizeFileWithHandle:(CSHandle *)handle firstBytes:(NSData *)data name:(NSString *)name;
++(BOOL)recognizeFileWithHandle:(CSHandle *)handle firstBytes:(NSData *)data name:(NSString *)name propertiesToAdd:(NSMutableDictionary *)props;
 -(NSString *)formatName;
 
 @end

--- a/XADZipSFXParsers.m
+++ b/XADZipSFXParsers.m
@@ -25,7 +25,7 @@
 
 +(int)requiredHeaderSize { return 0x10000; }
 
-+(BOOL)recognizeFileWithHandle:(CSHandle *)handle firstBytes:(NSData *)data name:(NSString *)name;
++(BOOL)recognizeFileWithHandle:(CSHandle *)handle firstBytes:(NSData *)data name:(NSString *)name propertiesToAdd:(NSMutableDictionary *)props;
 {
 	const uint8_t *bytes=[data bytes];
 	int length=[data length];
@@ -35,8 +35,12 @@
 
 	for(int i=2;i<length-9;i++)
 	{
-		if(bytes[i]=='P'&&bytes[i+1]=='K'&&bytes[i+2]==3&&bytes[i+3]==4)
-		if(bytes[i+4]>=10&&bytes[i+4]<40&&!bytes[i+9]) return YES;
+        if(bytes[i]=='P'&&bytes[i+1]=='K'&&bytes[i+2]==3&&bytes[i+3]==4) {
+            if(bytes[i+4]>=10&&bytes[i+4]<40&&!bytes[i+9]) {
+                [props setObject:[NSNumber numberWithLongLong:i] forKey:@"FoundSignatureOffset"];
+                return YES;
+            }
+        }
     }
 
 	return NO;

--- a/XADZipSFXParsers.m
+++ b/XADZipSFXParsers.m
@@ -37,7 +37,7 @@
 	{
         if(bytes[i]=='P'&&bytes[i+1]=='K'&&bytes[i+2]==3&&bytes[i+3]==4) {
             if(bytes[i+4]>=10&&bytes[i+4]<40&&!bytes[i+9]) {
-                [props setObject:[NSNumber numberWithLongLong:i] forKey:@"FoundSignatureOffset"];
+                [props setObject:[NSNumber numberWithLongLong:i] forKey:XADSignatureOffset];
                 return YES;
             }
         }


### PR DESCRIPTION
## What
Added option to select best-matching parser

## Why
In case if signature can be found by different parsers, we had only one option - to choose which one will come first. Now, parser is selected, based on the signature location

i.e.e

```
Valid Rar with zip signaure inside
|----|RAR-Signature|-----|Zip-Signature|-|  

Valid ZIP with RAR signaure inside
|--|Zip-Signature| -----|RAR-Signature|------|
```