### PR TITLE
Check ZIP extra field if >= 9 bytes

### DIFF
--- a/XADZipParser.m
+++ b/XADZipParser.m
@@ -636,7 +636,7 @@ uncompressedSizePointer:(off_t *)uncompsizeptr compressedSizePointer:(off_t *)co
 
 	off_t end=[fh offsetInFile]+length;
 
-	while(length>9)
+	while(length>=9)
 	{
 		int extid=[fh readUInt16LE];
 		int size=[fh readUInt16LE];


### PR DESCRIPTION
A 9 byte extra field contains a valid `extid[2]`, `size[2]`, `flag[1]` and `object[4]`.
Found [here](https://github.com/aonez/Keka/issues/422), a valid extra field informing an extended timestamp was ignored.