### PR TITLE
fixed crash during unarchive sitx format with symlink on deleted file

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
           path: UniversalDetector
 
       - name: Install libs
-        run: sudo apt-get install build-essential libgnustep-base-dev libz-dev libbz2-dev libssl-dev libicu-dev libwavpack-dev
+        run: sudo apt-get update && sudo apt-get install --fix-missing build-essential libgnustep-base-dev libz-dev libbz2-dev libssl-dev libicu-dev libwavpack-dev
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
 
       # Preinsatll libs
       - name: Install libs
-        run: sudo apt-get install build-essential libgnustep-base-dev libz-dev libbz2-dev libssl-dev libicu-dev libwavpack-dev
+        run: sudo apt-get update && sudo apt-get install --fix-missing build-essential libgnustep-base-dev libz-dev libbz2-dev libssl-dev libicu-dev libwavpack-dev
 
       # Runs a single command using the runners shell
       - name: Build project

--- a/XADUnarchiver.m
+++ b/XADUnarchiver.m
@@ -430,7 +430,9 @@ resourceForkDictionary:(NSDictionary *)forkdict wantChecksum:(BOOL)checksum erro
 
 	NSString *linkdest=nil;
 	if(delegate) linkdest=[delegate unarchiver:self destinationForLink:link from:destpath];
-	if(!linkdest) return XADNoError; // Handle nil returns as a request to skip.
+    // linkdest can be empty or nil if the link points to a deleted file.
+    // linkdest must have a value to be used in the fileSystemRepresentation, otherwise it will crash.
+    if(!linkdest || linkdest.length == 0) return XADNoError; // Handle nil returns as a request to skip.
 
 	// Check if the link destination is an absolute path, or if it contains
 	// any .. path components.


### PR DESCRIPTION
# What
<!-- Describe the general information about what this Pull Request is about -->
- If the sitx archive contains a symlink to a deleted file, then we get an empty string in linkdest and when we try to get fileSystemRepresentation we catch a crash.
- There were mentions of this crash in the issue #36
# Impacted Areas
<!-- List general components of the application that this Pull Request affects -->
- XADUnarchiver
# Screenshots
![image](https://github.com/MacPaw/XADMaster/assets/128129514/357de1e9-347f-416f-925f-aea423c08145)
<img width="726" alt="CleanShot 2023-08-03 at 16 54 16@2x" src="https://github.com/MacPaw/XADMaster/assets/128129514/9424221d-c8b7-4b72-9129-027ddf5ed0b1">