### PR TITLE
Fix/crash corrupted iso

### DIFF
--- a/XADISO9660Parser.m
+++ b/XADISO9660Parser.m
@@ -643,15 +643,35 @@ length:(uint32_t)length
 						break;
 
 						case TypeID('C','E'):
-						{
-							if(length!=28) break;
-							if(system[pos+3]!=1) break;
-
-							uint32_t block=CSUInt32LE(&system[pos+4]);
-							uint32_t offset=CSUInt32LE(&system[pos+12]);
-							nextoffset=block*2048+offset;
-
-							nextlength=CSUInt32LE(&system[pos+20]);
+                        {
+                            if(length!=28) break;
+                            if(system[pos+3]!=1) break;
+                            
+                            /**
+                             This region is a SUSP, define in SUSP IEEE P1281 section 5.1, which says that
+                             the next fields shall be recorded according to ISO 9660:1988 Format section 7.3.3.
+                             From ISO 9660:1988 7.3.3:
+                             "A numerical value represented by the hexadecimal representation (st uv wx yz)
+                             shall be recorded in an eight- byte field as (yz wx uv st st uv wx yz)."
+                             
+                             We can read the next fields in BigEndian and LittleEndian format
+                             and compare then in order to determine if the SUSP CE block is corrupted.
+                             */
+                            uint32_t blockLE=CSUInt32LE(&system[pos+4]);
+                            uint32_t blockBE = CSUInt32BE(&system[pos+8]);
+                            
+                            uint32_t offsetLE=CSUInt32LE(&system[pos+12]);
+                            uint32_t offsetBE = CSUInt32BE(&system[pos+16]);
+                            
+                            uint32_t lengthLE=CSUInt32LE(&system[pos+20]);
+                            uint32_t lengthBE = CSUInt32BE(&system[pos+24]);
+                            
+                            if (blockLE!=blockBE || offsetLE!=offsetBE || lengthLE!=lengthBE) {
+                                break;
+                            }
+                            
+                            nextoffset = blockLE * 2048 + offsetLE;
+                            nextlength = length;
 						}
 						break;
 

--- a/XADISO9660Parser.m
+++ b/XADISO9660Parser.m
@@ -644,8 +644,8 @@ length:(uint32_t)length
 
 						case TypeID('C','E'):
                         {
-                            if(length!=28) break;
-                            if(system[pos+3]!=1) break;
+                            if (length != 28) break;
+                            if (system[pos+3] != 1) break;
                             
                             /**
                              This region is a SUSP, define in SUSP IEEE P1281 section 5.1, which says that
@@ -657,16 +657,16 @@ length:(uint32_t)length
                              We can read the next fields in BigEndian and LittleEndian format
                              and compare then in order to determine if the SUSP CE block is corrupted.
                              */
-                            uint32_t blockLE=CSUInt32LE(&system[pos+4]);
+                            uint32_t blockLE = CSUInt32LE(&system[pos+4]);
                             uint32_t blockBE = CSUInt32BE(&system[pos+8]);
                             
-                            uint32_t offsetLE=CSUInt32LE(&system[pos+12]);
+                            uint32_t offsetLE = CSUInt32LE(&system[pos+12]);
                             uint32_t offsetBE = CSUInt32BE(&system[pos+16]);
                             
-                            uint32_t lengthLE=CSUInt32LE(&system[pos+20]);
+                            uint32_t lengthLE = CSUInt32LE(&system[pos+20]);
                             uint32_t lengthBE = CSUInt32BE(&system[pos+24]);
                             
-                            if (blockLE!=blockBE || offsetLE!=offsetBE || lengthLE!=lengthBE) {
+                            if (blockLE != blockBE || offsetLE != offsetBE || lengthLE != lengthBE) {
                                 break;
                             }
                             

--- a/XADISO9660Parser.m
+++ b/XADISO9660Parser.m
@@ -671,7 +671,7 @@ length:(uint32_t)length
                             }
                             
                             nextoffset = blockLE * 2048 + offsetLE;
-                            nextlength = length;
+                            nextlength = lengthLE;
 						}
 						break;
 


### PR DESCRIPTION
# What
<!-- Describe the general information about what this Pull Request is about -->
- If an ISO 9660 file contains a malformed SUSP extension XADMaster crashes.

# Impacted Areas
<!-- List general components of the application that this Pull Request affects -->
- XADUnarchiver

# Details
Let's open an ISO image file with malformed CE SUSP section and view the memory of that section

![Screenshot 2023-09-06 at 13 49 23](https://github.com/MacPaw/XADMaster/assets/63403229/6e9ffd59-2945-4c69-8ff1-4560019f6855)

![Screenshot 2023-09-06 at 13 49 00](https://github.com/MacPaw/XADMaster/assets/63403229/21b0cea7-6406-4c3d-8e50-8c164d61d57b)


Lets read the SUSP, IEEE P1281 standard which says:

> The format of the "CE" System Use Field is as follows:
> [1] "BP 1 to BP 2 - Signature Word" shall indicate that the System Use Field is a "CE" type System Use Field. The bytes in this field shall be (43)(45) ("CE") 
> [2] "BP 3 - Length (LEN_SUF)" shall specify as an 8-bit number the length in bytes of the "CE" System Use Field. The number in this field shall be 28 for this version. This field shall be recorded according to the **ISO 9660:1988 Format section 7.1.1**.
> [3] "BP 4 - System Use Field Version" shall specify as an 8-bit number an identification of the version of the "CE" System Use Field. The number in this field shall be 1 for this version. This field shall be recorded according to the **ISO 9660:1988 Format section 7.1.1**.
> [4] "BP 5 to BP 12 - Location of Continuation of System Use Area" shall specify as a 32-bit number the Logical Block Number of the first Logical Block of the Logical Sector that contains the start of this Continuation of the Sytem Use Area. This field shall be recorded according to the **ISO 9660:1988 Format section 7.3.3**.
> [5] "BP 13 to BP 20 - Offset to Start of Continuation" shall specify as a 32-bit number the offset, in bytes, from the start of the block specified in [4] above to the start of the area that is to be used for this Continuation of the System Use Area. This field shall be recorded according to the **ISO 9660:1988 Format section 7.3.3**.

 ISO 9660:1988 Format section 7.1.1:

> 8-bit unsigned numerical vaiues
> An unsigned numerical value shall be represented in binary notation by an 8-bit number recorded in a one-byte field.

 ISO 9660:1988 Format section 7.3.3:

> Both-byte orders
> A numerical value represented by the hexadecimal representation (st uv wx yz) shall be recorded in an eight- byte field as (yz wx uv st st uv wx yz).
> NOTE 14
> For example, the decimal number 305419896 has (12 34 56 78) as its hexadecimal representation and is recorded as (78 56 34 12 12 34 56 78).

Lets check it with our memory
43 45 1C 01 00 00 00 BF 00 00 00 4D 00 00 00 4D DB 29 00 00 

[1] (43, 45) - Correct
[2] (1C) - Correct
[3] (01) - Correct
[4] (00 00 00 BF 00 00 00 4D) Not correct, because this field is `Both byte order` (see above), so 0xBF000000 should be equal to 0x0000004D
[5] (00 00 00 4D DB 29 00 00) Not correct, because this field is `Both byte order` (see above), so 0x4D000000 should be equal to 0xDB290000

