### PR TITLE
Do not crash when parsing System Use field (of Directory Record) if ISO missing the padding bit

### DIFF
--- a/XADISO9660Parser.m
+++ b/XADISO9660Parser.m
@@ -407,7 +407,7 @@ length:(uint32_t)length
 		if(flags&0x04) [dict setObject:[NSNumber numberWithBool:YES] forKey:XADIsDirectoryKey];
 
 		int systemlength=recordlength-33-namelength-((namelength&1)^1);
-		if(systemlength)
+		if(systemlength>0)
 		{
 			NSMutableData *namedata=nil;
 			NSMutableData *linkdata=nil;


### PR DESCRIPTION
According to [ISO 9660 standard](https://ecma-international.org/wp-content/uploads/ECMA-119_3rd_edition_december_2017.pdf) when parsing Directory Record (section 9.1) and the File Identifier (file name) length is an even number, a padding bit of value 0x0 should be followed the file File Identifier bit (section 9.1.12); Some of the ISO tools doesn't add the padding field which leads to the parser crash.

More explanation
From the existing code:
`systemlength=recordlength-33-namelength-((namelength&1)^1);`
`systemlength` - System Use record length (part of Directory record)
`recordlength` - Directory Record length (part of Directory record)
`33` - the offset of the File Identifier (part of Directory record)
`namelength` - length of the File Identifier record (part of Directory Record)
`-((namelength&1)^1)` if namelength is even number, return -1

and so, if there is no padding byte after file name and System Usage record is 0, systemlength equals to -1, and 
`if(systemlength) `
calls the body

![Compare_iso_files](https://github.com/MacPaw/XADMaster/assets/63403229/77edcd25-2437-49ef-bb06-3f3d1a78d3d6)
