### PR TITLE
make CSMemoryHandle visible when XADMaster imported as a clang module

### DIFF
--- a/XADMaster.h
+++ b/XADMaster.h
@@ -32,3 +32,4 @@ FOUNDATION_EXPORT const unsigned char XADMasterVersionString[];
 #import <XADMaster/XADPrefixCode.h>
 #import <XADMaster/XADSimpleUnarchiver.h>
 #import <XADMaster/XADArchiveParserDescriptions.h>
+#import <XADMaster/CSMemoryHandle.h>


### PR DESCRIPTION
`CSMemoryHandle` is a public header which means it can be imported as
`#import <XADMaster/CSMemoryHandle.h>`
But `CSMemoryHandle.h` is not in umbrella header `XADMaster.h` therefore when `XADMaster` is imported as a clang module
`@import XADMaster`
`CSMemoryHandle` is not visible.
This PR fixes `CSMemoryHandle` visibility in `XADMaster` module