### PR TITLE
Only check RAR5 signature elsewhere on executables

### DIFF
--- a/XADRAR5Parser.m
+++ b/XADRAR5Parser.m
@@ -43,6 +43,11 @@ static BOOL IsRAR5Signature(const uint8_t *ptr)
 	ptr[4]==0x1a && ptr[5]==0x07 && ptr[6]==0x01 && ptr[7]==0x00;
 }
 
+static BOOL IsSFXSignature(const uint8_t *ptr)
+{
+	return ptr[0]=='M' && ptr[1]=='Z';
+}
+
 static uint64_t ReadRAR5VInt(CSHandle *handle)
 {
 	uint64_t res=0;
@@ -86,8 +91,13 @@ static inline BOOL IsZeroHeaderBlock(RAR5HeaderBlock block) { return IsZeroBlock
     
     if(length<8) return RAR5SignatureNotFound; // TODO: fix to use correct min size
     
-    // for SFXX, RAR Signature can be found not at start, but anywhere in the data
-    int maxxSearch = MIN(length, RAR5MaximumSFXHeader) - 8;
+	int maxxSearch = 8;
+	
+    // For SFXX, RAR Signature can be found not at start, but anywhere in the data,
+	// but be sure it has the executable signature first
+	if (IsSFXSignature(bytes)) {
+		maxxSearch = MIN(length, RAR5MaximumSFXHeader) - 8;
+	}
     
     const uint8_t *sign = bytes;
     for (int i =0 ; i < maxxSearch; i++, sign++) {


### PR DESCRIPTION
Previously the `RAR5` signature was checked in all the available "header" bytes.
This is prone to issues for example if a TAR contains some `RAR5` files giving false detections and incomplete or failed extractions.

To fix this I'm just adding an executable signature check (`MZ`) before using all length or `RAR5MaximumSFXHeader` to check for the `RAR5` signature.

I'm attaching some example files:

- `rar-v4.tar`: contains a RAR4 file. Is detected as TAR and extracts the bare .rar file.
- `rar-v5.tar`: contains a RAR5 file. Is detected as RAR5 and extracts the contents of the RAR inside the TAR.
- `parted-rar-v5.tar`: contains a three parts RAR5 volume. Is detected as `RAR5` and fails as tries to extract the first part found.

Did not tried but I'm assuming if the TAR file contains more files a part from the `RAR5`, and this one is detected, the other files will be dismissed.

[Examples.zip](https://github.com/user-attachments/files/15524744/Examples.zip)

