### PR TITLE
Fix signed overflow in DMS endian decoding

### DIFF
--- a/XADMaster.xcodeproj/project.pbxproj
+++ b/XADMaster.xcodeproj/project.pbxproj
@@ -1415,6 +1415,7 @@
 		734C13B921C79C8500917EAA /* unpack_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 734C13B621C79C8400917EAA /* unpack_utils.c */; };
 		734C13BA21C79C8500917EAA /* unpack_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 734C13B621C79C8400917EAA /* unpack_utils.c */; };
 		7378D98B21CCD04000A4B11F /* CRCCalculationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7378D98A21CCD04000A4B11F /* CRCCalculationTests.m */; };
+		73F0AA6402D14A5300A1B2C3 /* EndianConversionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 73F0AA6302D14A5300A1B2C3 /* EndianConversionTests.m */; };
 		7398C7AE2059248700D7B977 /* UniversalDetector.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B06D3770DDA5C2600D9C000 /* UniversalDetector.framework */; };
 		73A91A542ADC64DE0059C423 /* StuffitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 73A91A4F2ADC64DE0059C423 /* StuffitTests.m */; };
 		73A91A562ADC64EB0059C423 /* StuffitFixtures in Resources */ = {isa = PBXBuildFile; fileRef = 73A91A552ADC64EB0059C423 /* StuffitFixtures */; };
@@ -2144,6 +2145,7 @@
 		734C13B121C79B1A00917EAA /* unpack_seek.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = unpack_seek.c; sourceTree = "<group>"; };
 		734C13B621C79C8400917EAA /* unpack_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = unpack_utils.c; sourceTree = "<group>"; };
 		7378D98A21CCD04000A4B11F /* CRCCalculationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CRCCalculationTests.m; sourceTree = "<group>"; };
+		73F0AA6302D14A5300A1B2C3 /* EndianConversionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EndianConversionTests.m; sourceTree = "<group>"; };
 		73A91A4F2ADC64DE0059C423 /* StuffitTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StuffitTests.m; sourceTree = "<group>"; };
 		73A91A552ADC64EB0059C423 /* StuffitFixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; path = StuffitFixtures; sourceTree = "<group>"; };
 		73DA3465206B6BF1006ADB42 /* XADMasterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XADMasterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3279,6 +3281,7 @@
 				E424FB4621CAE11D00E1C950 /* XADArchiveParserTests.m */,
 				E424FB4D21CAEC0300E1C950 /* XADZipParserTests.m */,
 				7378D98A21CCD04000A4B11F /* CRCCalculationTests.m */,
+				73F0AA6302D14A5300A1B2C3 /* EndianConversionTests.m */,
 				E46E6295225DC2DE00D44E0A /* XADSFXDetectionParserTests.m */,
 				C4C3241727AC25E9007919DB /* XADZippedBzip2LeakTests.m */,
 				C4C3241927AC2655007919DB /* eicar.bz */,
@@ -4777,6 +4780,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7378D98B21CCD04000A4B11F /* CRCCalculationTests.m in Sources */,
+				73F0AA6402D14A5300A1B2C3 /* EndianConversionTests.m in Sources */,
 				73A91A542ADC64DE0059C423 /* StuffitTests.m in Sources */,
 				73032E6C2626D3DD000C2751 /* XADWARCParserTests.m in Sources */,
 				73DA3468206B6BF1006ADB42 /* XADPlatformOSXTests.m in Sources */,

--- a/XADMasterTests/EndianConversionTests.m
+++ b/XADMasterTests/EndianConversionTests.m
@@ -1,0 +1,30 @@
+//
+//  EndianConversionTests.m
+//  XADMasterTests
+//
+
+#import <XCTest/XCTest.h>
+#import "../libxad/include/xadmaster.h"
+#import "../libxad/include/ConvertE.c"
+
+@interface EndianConversionTests : XCTestCase
+
+@end
+
+@implementation EndianConversionTests
+
+- (void)testEndGetM32ParsesDMSMagic {
+    const unsigned char bytes[] = { 'D', 'M', 'S', '!' };
+
+    XCTAssertEqual(EndGetM32(bytes), (xadUINT32)0x444D5321u);
+}
+
+- (void)testEndGetM32HandlesHighBitSetMostSignificantByteWithoutSignedOverflow {
+    // This is the UBSan reproducer for the legacy implementation:
+    // the old macro evaluated `201 << 24` as a signed int shift.
+    const unsigned char bytes[] = { 201, 0x44, 0x53, 0x21 };
+
+    XCTAssertEqual(EndGetM32(bytes), (xadUINT32)0xC9445321u);
+}
+
+@end

--- a/libxad/include/ConvertE.c
+++ b/libxad/include/ConvertE.c
@@ -41,35 +41,35 @@
  * I16 - little-endian Intel format, 16 bit value
  */
 
-#define EndGetM32(a)  (((((unsigned char *) a)[0]) << 24) |             \
-                       ((((unsigned char *) a)[1]) << 16) |             \
-                       ((((unsigned char *) a)[2]) <<  8) |             \
-                       ((((unsigned char *) a)[3])))
-#define EndGetM24(a)  (((((unsigned char *) a)[0]) << 16) |             \
-                       ((((unsigned char *) a)[1]) <<  8) |             \
-                       ((((unsigned char *) a)[2])))
-#define EndGetM16(a)  (((((unsigned char *) a)[0]) <<  8) |             \
-                       ((((unsigned char *) a)[1])))
+#define EndGetM32(a)  (((xadUINT32) (((unsigned char *) a)[0]) << 24) | \
+                       ((xadUINT32) (((unsigned char *) a)[1]) << 16) | \
+                       ((xadUINT32) (((unsigned char *) a)[2]) <<  8) | \
+                       ((xadUINT32) (((unsigned char *) a)[3])))
+#define EndGetM24(a)  (((xadUINT32) (((unsigned char *) a)[0]) << 16) | \
+                       ((xadUINT32) (((unsigned char *) a)[1]) <<  8) | \
+                       ((xadUINT32) (((unsigned char *) a)[2])))
+#define EndGetM16(a)  (((xadUINT32) (((unsigned char *) a)[0]) <<  8) | \
+                       ((xadUINT32) (((unsigned char *) a)[1])))
 
-#define EndGetI32(a)  (((((unsigned char *) a)[3]) << 24) |             \
-                       ((((unsigned char *) a)[2]) << 16) |             \
-                       ((((unsigned char *) a)[1]) <<  8) |             \
-                       ((((unsigned char *) a)[0])))
-#define EndGetI24(a)  (((((unsigned char *) a)[2]) << 16) |             \
-                       ((((unsigned char *) a)[1]) <<  8) |             \
-                       ((((unsigned char *) a)[0])))
-#define EndGetI16(a)  (((((unsigned char *) a)[1]) <<  8) |             \
-                       ((((unsigned char *) a)[0])))
+#define EndGetI32(a)  (((xadUINT32) (((unsigned char *) a)[3]) << 24) | \
+                       ((xadUINT32) (((unsigned char *) a)[2]) << 16) | \
+                       ((xadUINT32) (((unsigned char *) a)[1]) <<  8) | \
+                       ((xadUINT32) (((unsigned char *) a)[0])))
+#define EndGetI24(a)  (((xadUINT32) (((unsigned char *) a)[2]) << 16) | \
+                       ((xadUINT32) (((unsigned char *) a)[1]) <<  8) | \
+                       ((xadUINT32) (((unsigned char *) a)[0])))
+#define EndGetI16(a)  (((xadUINT32) (((unsigned char *) a)[1]) <<  8) | \
+                       ((xadUINT32) (((unsigned char *) a)[0])))
 
 /* 64-bit support */
-#define _convM32(a,n)(((((unsigned char *) a)[n+0]) << 24) |            \
-                      ((((unsigned char *) a)[n+1]) << 16) |            \
-                      ((((unsigned char *) a)[n+2]) <<  8) |            \
-                      ((((unsigned char *) a)[n+3])))
-#define _convI32(a,n)(((((unsigned char *) a)[n+3]) << 24) |            \
-                      ((((unsigned char *) a)[n+2]) << 16) |            \
-                      ((((unsigned char *) a)[n+1]) <<  8) |            \
-                      ((((unsigned char *) a)[n+0])))
+#define _convM32(a,n)(((xadUINT32) (((unsigned char *) a)[n+0]) << 24) | \
+                      ((xadUINT32) (((unsigned char *) a)[n+1]) << 16) | \
+                      ((xadUINT32) (((unsigned char *) a)[n+2]) <<  8) | \
+                      ((xadUINT32) (((unsigned char *) a)[n+3])))
+#define _convI32(a,n)(((xadUINT32) (((unsigned char *) a)[n+3]) << 24) | \
+                      ((xadUINT32) (((unsigned char *) a)[n+2]) << 16) | \
+                      ((xadUINT32) (((unsigned char *) a)[n+1]) <<  8) | \
+                      ((xadUINT32) (((unsigned char *) a)[n+0])))
 
 #if defined(AMIGA) /* AMIGA XAD has not 64 bit types yet */
 #  define EndGetI64(a) ((unsigned int) _convi32(a,0))


### PR DESCRIPTION
## Summary
- cast endian-conversion macro bytes to xadUINT32 before shifting to avoid signed overflow UB
- add a regression test for the DMS magic value and the UBSan reproducer with a high-bit first byte
- register the new test in the XADMasterTests target

## Testing
- attempted to run XADMasterTests/EndianConversionTests locally
- xcodebuild in this environment is blocked from completing test execution by macOS signing/sandbox constraints, so runtime verification is still pending on a fully provisioned machine