### PR TITLE
Fix CRC endianness detection and add s390x regression

### DIFF
--- a/.github/workflows/crc-big-endian.yml
+++ b/.github/workflows/crc-big-endian.yml
@@ -28,6 +28,7 @@ jobs:
               set -eux
               apt-get update
               apt-get install -y --no-install-recommends gcc gobjc gnustep-make libgnustep-base-dev
+              . /usr/share/GNUstep/Makefiles/GNUstep.sh
               gcc $(gnustep-config --objc-flags) -std=gnu99 -I. -c CRC.m -o CRC.o
               gcc $(gnustep-config --objc-flags) -std=gnu99 -I. -c Tests/CRCFastRegression.m -o CRCFastRegression.o
               gcc CRC.o CRCFastRegression.o -o crc-fast-regression $(gnustep-config --base-libs)

--- a/.github/workflows/crc-big-endian.yml
+++ b/.github/workflows/crc-big-endian.yml
@@ -27,12 +27,11 @@ jobs:
             bash -lc '
               set -eux
               apt-get update
-              apt-get install -y --no-install-recommends gcc gobjc gnustep-make libgnustep-base-dev
-              set +u
-              . /usr/share/GNUstep/Makefiles/GNUstep.sh
-              set -u
-              gcc $(gnustep-config --objc-flags) -std=gnu99 -I. -c CRC.m -o CRC.o
-              gcc $(gnustep-config --objc-flags) -std=gnu99 -I. -c Tests/CRCFastRegression.m -o CRCFastRegression.o
-              gcc CRC.o CRCFastRegression.o -o crc-fast-regression $(gnustep-config --base-libs)
+              apt-get install -y --no-install-recommends gcc gobjc libgnustep-base-dev libobjc-12-dev
+              OBJCFLAGS="-std=gnu99 -I. -I/usr/include/GNUstep -fconstant-string-class=NSConstantString"
+              LDFLAGS="-lgnustep-base -lobjc"
+              gcc $OBJCFLAGS -c CRC.m -o CRC.o
+              gcc $OBJCFLAGS -c Tests/CRCFastRegression.m -o CRCFastRegression.o
+              gcc CRC.o CRCFastRegression.o -o crc-fast-regression $LDFLAGS
               ./crc-fast-regression
             '

--- a/.github/workflows/crc-big-endian.yml
+++ b/.github/workflows/crc-big-endian.yml
@@ -1,4 +1,4 @@
-name: Debian Tests
+name: Big Endian Systems (Debian)
 
 on:
   push:

--- a/.github/workflows/crc-big-endian.yml
+++ b/.github/workflows/crc-big-endian.yml
@@ -1,4 +1,4 @@
-name: CRC Big Endian
+name: Debian Tests
 
 on:
   push:
@@ -8,6 +8,7 @@ on:
 
 jobs:
   crc-s390x:
+    name: CRC Regression (s390x)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/crc-big-endian.yml
+++ b/.github/workflows/crc-big-endian.yml
@@ -3,6 +3,8 @@ name: Big Endian Systems (Debian)
 on:
   push:
     branches: [ master ]
+    # Keep this emulated s390x job scoped to the CRC/endian code it protects.
+    # The workflow file itself stays in the filter so trigger changes can verify.
     paths:
       - .github/workflows/crc-big-endian.yml
       - CRC.m
@@ -12,6 +14,8 @@ on:
       - XADMasterTests/CRCCalculationTests.m
   pull_request:
     branches: [ master ]
+    # Keep this emulated s390x job scoped to the CRC/endian code it protects.
+    # The workflow file itself stays in the filter so trigger changes can verify.
     paths:
       - .github/workflows/crc-big-endian.yml
       - CRC.m

--- a/.github/workflows/crc-big-endian.yml
+++ b/.github/workflows/crc-big-endian.yml
@@ -3,8 +3,22 @@ name: Big Endian Systems (Debian)
 on:
   push:
     branches: [ master ]
+    paths:
+      - .github/workflows/crc-big-endian.yml
+      - CRC.m
+      - CRC.h
+      - Crypto/brg_endian.h
+      - Tests/CRCFastRegression.m
+      - XADMasterTests/CRCCalculationTests.m
   pull_request:
     branches: [ master ]
+    paths:
+      - .github/workflows/crc-big-endian.yml
+      - CRC.m
+      - CRC.h
+      - Crypto/brg_endian.h
+      - Tests/CRCFastRegression.m
+      - XADMasterTests/CRCCalculationTests.m
 
 jobs:
   crc-s390x:

--- a/.github/workflows/crc-big-endian.yml
+++ b/.github/workflows/crc-big-endian.yml
@@ -1,0 +1,35 @@
+name: CRC Big Endian
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  crc-s390x:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: s390x
+
+      - name: Run CRC regression on s390x
+        run: |
+          docker run --rm --platform linux/s390x \
+            -v "$GITHUB_WORKSPACE:/work" \
+            -w /work \
+            debian:bookworm-slim \
+            bash -lc '
+              set -eux
+              apt-get update
+              apt-get install -y --no-install-recommends gcc gobjc gnustep-make libgnustep-base-dev
+              gcc $(gnustep-config --objc-flags) -std=gnu99 -I. -c CRC.m -o CRC.o
+              gcc $(gnustep-config --objc-flags) -std=gnu99 -I. -c Tests/CRCFastRegression.m -o CRCFastRegression.o
+              gcc CRC.o CRCFastRegression.o -o crc-fast-regression $(gnustep-config --base-libs)
+              ./crc-fast-regression
+            '

--- a/.github/workflows/crc-big-endian.yml
+++ b/.github/workflows/crc-big-endian.yml
@@ -28,7 +28,9 @@ jobs:
               set -eux
               apt-get update
               apt-get install -y --no-install-recommends gcc gobjc gnustep-make libgnustep-base-dev
+              set +u
               . /usr/share/GNUstep/Makefiles/GNUstep.sh
+              set -u
               gcc $(gnustep-config --objc-flags) -std=gnu99 -I. -c CRC.m -o CRC.o
               gcc $(gnustep-config --objc-flags) -std=gnu99 -I. -c Tests/CRCFastRegression.m -o CRCFastRegression.o
               gcc CRC.o CRCFastRegression.o -o crc-fast-regression $(gnustep-config --base-libs)

--- a/CRC.m
+++ b/CRC.m
@@ -19,6 +19,7 @@
  * MA 02110-1301  USA
  */
 #import "Checksums.h"
+#import "Crypto/brg_endian.h"
 
 uint32_t XADCRC(uint32_t prevcrc,uint8_t byte,const uint32_t *table)
 {
@@ -32,7 +33,7 @@ uint32_t XADCalculateCRC(uint32_t prevcrc,const uint8_t *buffer,int length,const
 	return crc;
 }
 
-#if XAD_BYTE_ORDER_BIG_ENDIAN
+#if PLATFORM_BYTE_ORDER == IS_BIG_ENDIAN
 static inline uint32_t swap(uint32_t x)
 {
 #if defined(__GNUC__) || defined(__clang__)
@@ -58,7 +59,7 @@ uint32_t XADCalculateCRCFast(uint32_t prevcrc,const uint8_t *buffer,int length, 
     {
         for (size_t unrolling = 0; unrolling < Unroll; unrolling++)
         {
-#if XAD_BYTE_ORDER_BIG_ENDIAN
+#if PLATFORM_BYTE_ORDER == IS_BIG_ENDIAN
             uint32_t a   = *pos++ ^ swap(crc);
             uint32_t b   = *pos++;
             uint32_t c   = *pos++;

--- a/Tests/CRCFastRegression.m
+++ b/Tests/CRCFastRegression.m
@@ -1,0 +1,36 @@
+#import <stdint.h>
+#import <stdio.h>
+
+#import "CRC.h"
+
+static int run_crc_check(const uint8_t *buffer, int length, const char *label)
+{
+    uint32_t slow = XADCalculateCRC(0xFFFFFFFFu, buffer, length, XADCRCTable_edb88320);
+    uint32_t fast = XADCalculateCRCFast(0xFFFFFFFFu, buffer, length, XADCRCTable_sliced16_edb88320);
+
+    if (slow != fast) {
+        fprintf(stderr, "%s mismatch: slow=0x%08x fast=0x%08x length=%d\n", label, slow, fast, length);
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    uint32_t words[128];
+    uint8_t *buffer = (uint8_t *)words;
+    int failed = 0;
+
+    // Use deterministic data so the regression is stable across environments.
+    for (size_t i = 0; i < (sizeof(words) / sizeof(words[0])); i++) {
+        words[i] = (uint32_t)(0x9E3779B9u * (uint32_t)(i + 1u)) ^ (uint32_t)(0xA5A5A5A5u + (uint32_t)i);
+    }
+
+    failed |= run_crc_check(buffer, 64, "exact-fast-block");
+    failed |= run_crc_check(buffer, 65, "fast-block-plus-tail");
+    failed |= run_crc_check(buffer, 127, "multi-block-odd-tail");
+    failed |= run_crc_check(buffer, (int)sizeof(words), "full-buffer");
+
+    return failed;
+}

--- a/XADMasterTests/CRCCalculationTests.m
+++ b/XADMasterTests/CRCCalculationTests.m
@@ -28,6 +28,22 @@ typedef struct XADCRCTestsSUT {
     [self _free:sut];
 }
 
+- (void)testFastCRCCalculationMatchesSlowCRCForDeterministicRegressionBuffers {
+    uint32_t words[128];
+    uint8_t *buffer = (uint8_t *)words;
+
+    // Keep this deterministic so the XCTest and s390x regression harness cover
+    // the same data shapes and failures.
+    for (size_t i = 0; i < (sizeof(words) / sizeof(words[0])); i++) {
+        words[i] = (uint32_t)(0x9E3779B9u * (uint32_t)(i + 1u)) ^ (uint32_t)(0xA5A5A5A5u + (uint32_t)i);
+    }
+
+    [self _assertFastCRCMatchesSlowCRCForBuffer:buffer length:64 label:@"exact-fast-block"];
+    [self _assertFastCRCMatchesSlowCRCForBuffer:buffer length:65 label:@"fast-block-plus-tail"];
+    [self _assertFastCRCMatchesSlowCRCForBuffer:buffer length:127 label:@"multi-block-odd-tail"];
+    [self _assertFastCRCMatchesSlowCRCForBuffer:buffer length:(int)sizeof(words) label:@"full-buffer"];
+}
+
 - (XADCRCTestsSUT)_sutWithBufferSize:(off_t)bufferSize {
     uint8_t * buffer = malloc(bufferSize);
     uint8_t * p = buffer;
@@ -43,5 +59,11 @@ typedef struct XADCRCTestsSUT {
     free(sut.buffer);
 }
 
+- (void)_assertFastCRCMatchesSlowCRCForBuffer:(const uint8_t *)buffer length:(int)length label:(NSString *)label {
+    uint32_t slowCRC = XADCalculateCRC(0xFFFFFFFFu, buffer, length, XADCRCTable_edb88320);
+    uint32_t fastCRC = XADCalculateCRCFast(0xFFFFFFFFu, buffer, length, XADCRCTable_sliced16_edb88320);
+
+    XCTAssertEqual(slowCRC, fastCRC, @"CRC mismatch for %@", label);
+}
 
 @end


### PR DESCRIPTION
## Summary
- switch CRC fast-path endianness detection to the existing `Crypto/brg_endian.h` logic
- stop relying on the undefined `XAD_BYTE_ORDER_BIG_ENDIAN` macro
- add a deterministic CRC regression binary
- run that regression in GitHub Actions under emulated `linux/s390x`

## Testing
- added a dedicated `CRC Big Endian` GitHub Actions workflow for `s390x`
- local runtime validation is pending on CI because the emulated container build requires networked package install
