### PR TITLE
docs: replace defunct Travis CI badge with GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Objective-C library for archive and file unarchiving and extraction
-[![Build Status](https://travis-ci.org/MacPaw/XADMaster.svg?branch=master)](https://travis-ci.org/MacPaw/XADMaster)
+[![Build](https://github.com/MacPaw/XADMaster/actions/workflows/main.yml/badge.svg)](https://github.com/MacPaw/XADMaster/actions/workflows/main.yml)
 * Supports multiple archive formats such as Zip, Tar, Gzip, Bzip2, 7-Zip, Rar, LhA, StuffIt, several old Amiga file and disk archives, CAB, LZX. Read [the wiki page](http://code.google.com/p/theunarchiver/wiki/SupportedFormats) for a more thorough listing of formats.
 * Supports split archives for certain formats, like RAR.
 * Uses [libxad](http://sourceforge.net/projects/libxad/) for older and more obscure formats. This is an old Amiga library for handling unpacking of archives.


### PR DESCRIPTION
## Summary

The README's build status badge points at \`travis-ci.org\`, which was shut down in mid-2021. The badge has been a broken image ever since.

The repo already has working GitHub Actions workflows (\`.github/workflows/main.yml\`), so this PR points the badge at that workflow instead.

## Before

![travis badge](https://travis-ci.org/MacPaw/XADMaster.svg?branch=master)

## After

[![Build](https://github.com/MacPaw/XADMaster/actions/workflows/main.yml/badge.svg)](https://github.com/MacPaw/XADMaster/actions/workflows/main.yml)

## Test plan

- [x] Badge URL renders correctly (linked to existing \`main.yml\` workflow)
- [x] No other references to \`travis-ci.org\` in the README