### PR TITLE
Fix memory leaks when exceptions bypass cleanup in archive parsers

### DIFF
--- a/XADCABParser.m
+++ b/XADCABParser.m
@@ -90,16 +90,22 @@ static CSHandle *FindHandleForName(NSData *namedata,NSString *dirname,NSArray *d
 		while(namedata)
 		{
 			NSAutoreleasePool *pool=[NSAutoreleasePool new];
+			NSData *nextnamedata=nil;
+			@try
+			{
+				CSHandle *fh=FindHandleForName(namedata,dirname,dircontents);
+				[volumes insertObject:[fh name] atIndex:0];
+				CABHeader head=ReadCABHeader(fh);
+				if(head.cabindex!=lastindex-1) @throw @"Index mismatch";
 
-			CSHandle *fh=FindHandleForName(namedata,dirname,dircontents);
-			[volumes insertObject:[fh name] atIndex:0];
-			CABHeader head=ReadCABHeader(fh);
-			if(head.cabindex!=lastindex-1) @throw @"Index mismatch";
-
-			namedata=[head.prevvolume retain];
-			lastindex=head.cabindex;
-			[pool release];
-			[namedata autorelease];
+				nextnamedata=[head.prevvolume retain];
+				lastindex=head.cabindex;
+			}
+			@finally
+			{
+				[pool release];
+			}
+			namedata=[nextnamedata autorelease];
 		}
 
 		if(lastindex!=0) @throw @"Couldn't find first volume";
@@ -110,16 +116,22 @@ static CSHandle *FindHandleForName(NSData *namedata,NSString *dirname,NSArray *d
 		while(namedata)
 		{
 			NSAutoreleasePool *pool=[NSAutoreleasePool new];
+			NSData *nextnamedata=nil;
+			@try
+			{
+				CSHandle *fh=FindHandleForName(namedata,dirname,dircontents);
+				[volumes addObject:[fh name]];
+				CABHeader head=ReadCABHeader(fh);
+				if(head.cabindex!=lastindex+1) @throw @"Index mismatch";
 
-			CSHandle *fh=FindHandleForName(namedata,dirname,dircontents);
-			[volumes addObject:[fh name]];
-			CABHeader head=ReadCABHeader(fh);
-			if(head.cabindex!=lastindex+1) @throw @"Index mismatch";
-
-			namedata=[head.nextvolume retain];
-			lastindex=head.cabindex;
-			[pool release];
-			[namedata autorelease];
+				nextnamedata=[head.nextvolume retain];
+				lastindex=head.cabindex;
+			}
+			@finally
+			{
+				[pool release];
+			}
+			namedata=[nextnamedata autorelease];
 		}
 	}
 	@catch(id e) { NSLog(@"CAB volume scanning error: %@",e); }

--- a/XADCFBFParser.m
+++ b/XADCFBFParser.m
@@ -30,6 +30,7 @@
 	{
 		sectable=NULL;
 		minisectable=NULL;
+		secvisitedtable=NULL;
 	}
 	return self;
 }
@@ -38,6 +39,7 @@
 {
 	free(sectable);
 	free(minisectable);
+	free(secvisitedtable);
 	[super dealloc];
 }
 

--- a/XADUnarchiver.m
+++ b/XADUnarchiver.m
@@ -687,8 +687,10 @@ outputTarget:(id)target selector:(SEL)selector argument:(id)argument
 	{
 		return [XADException parseException:e];
 	}
-
-	free(buf);
+	@finally
+	{
+		free(buf);
+	}
 
 	return XADNoError;
 }

--- a/XADZipParser.m
+++ b/XADZipParser.m
@@ -138,8 +138,13 @@
         off_t chunk_start = chunk_end - numbytes;
 
         uint8_t *buf = malloc(numbytes);
-        [fh seekToFileOffset:chunk_start];
-        [fh readBytes:numbytes toBuffer:buf];
+        @try {
+            [fh seekToFileOffset:chunk_start];
+            [fh readBytes:numbytes toBuffer:buf];
+        } @catch(id e) {
+            free(buf);
+            @throw;
+        }
 
         int preservedBytes = chunk_start >= 20 ? 20 : 0;
         int pos=numbytes-4;
@@ -285,68 +290,84 @@
 		if(![self shouldKeepParsing]) break;
 
 		NSAutoreleasePool *pool=[NSAutoreleasePool new];
-
-        XADZipParserCentralDirectoryRecord cdr = [self readCentralDirectoryRecord];
-
-        // Parse comment data
-		NSData *commentdata=nil;
-		if(cdr.commentlength) commentdata=[fh readDataOfLength:cdr.commentlength];
-        
-		off_t next=[fh offsetInFile];
-
-		// Some idiotic compressors write files with more than 65535 files without
-		// using Zip64, so numentries overflows. Try to detect if there is enough space
-		// left in the central directory for another 65536 files, and if so, extend the
-		// parsing to include them. This may happen multiple times.
-		if(i==numentries-1 && zip64offs<0)
+		@try
 		{
-			if(centraloffset+centralsize-next>65536*46) numentries+=65536;
-		}
+			XADZipParserCentralDirectoryRecord cdr = [self readCentralDirectoryRecord];
 
-		// Read local header
-		[fh seekToFileOffset:[self offsetForVolume:cdr.startdisk offset:cdr.locheaderoffset]];
+			// Parse comment data
+			NSData *commentdata=nil;
+			if(cdr.commentlength) commentdata=[fh readDataOfLength:cdr.commentlength];
 
-		uint32_t localid=[fh readID];
-		if(localid==0x504b0304||localid==0x504b0506) // kludge for strange archives
-		{
-			//int localextractversion=[fh readUInt16LE];
-			//int localflags=[fh readUInt16LE];
-			//int localcompressionmethod=[fh readUInt16LE];
-			[fh skipBytes:6];
-			uint32_t localdate=[fh readUInt32LE];
-			//uint32_t localcrc=[fh readUInt32LE];
-			//uint32_t localcompsize=[fh readUInt32LE];
-			//uint32_t localuncompsize=[fh readUInt32LE];
-			[fh skipBytes:12];
-			int localnamelength=[fh readUInt16LE];
-			int localextralength=[fh readUInt16LE];
+			off_t next=[fh offsetInFile];
 
-			off_t dataoffset=[fh offsetInFile]+localnamelength+localextralength;
-
-			NSData *namedata=nil;
-			if(localnamelength) namedata=[fh readDataOfLength:localnamelength];
-
-			NSDictionary *extradict=nil;
-			@try {
-				if(localextralength) extradict=[self parseZipExtraWithLength:localextralength nameData:namedata
-				uncompressedSizePointer:&cdr.uncompsize compressedSizePointer:&cdr.compsize];
-			} @catch(id e) {
-				[self setObject:[NSNumber numberWithBool:YES] forPropertyKey:XADIsCorruptedKey];
-				NSLog(@"Error parsing Zip extra fields: %@",e);
+			// Some idiotic compressors write files with more than 65535 files without
+			// using Zip64, so numentries overflows. Try to detect if there is enough space
+			// left in the central directory for another 65536 files, and if so, extend the
+			// parsing to include them. This may happen multiple times.
+			if(i==numentries-1 && zip64offs<0)
+			{
+				if(centraloffset+centralsize-next>65536*46) numentries+=65536;
 			}
 
-            // TODO: Consider using CDR struct
-			[self addZipEntryWithSystem:cdr.system extractVersion:cdr.extractversion flags:cdr.flags
-			compressionMethod:cdr.compressionmethod date:cdr.date crc:cdr.crc localDate:localdate
-			compressedSize:cdr.compsize uncompressedSize:cdr.uncompsize extendedFileAttributes:cdr.extfileattrib
-			extraDictionary:extradict dataOffset:dataoffset nameData:namedata commentData:commentdata
-			isLastEntry:i==numentries-1];
+			// Read local header
+			[fh seekToFileOffset:[self offsetForVolume:cdr.startdisk offset:cdr.locheaderoffset]];
+
+			uint32_t localid=[fh readID];
+			if(localid==0x504b0304||localid==0x504b0506) // kludge for strange archives
+			{
+				//int localextractversion=[fh readUInt16LE];
+				//int localflags=[fh readUInt16LE];
+				//int localcompressionmethod=[fh readUInt16LE];
+				[fh skipBytes:6];
+				uint32_t localdate=[fh readUInt32LE];
+				//uint32_t localcrc=[fh readUInt32LE];
+				//uint32_t localcompsize=[fh readUInt32LE];
+				//uint32_t localuncompsize=[fh readUInt32LE];
+				[fh skipBytes:12];
+				int localnamelength=[fh readUInt16LE];
+				int localextralength=[fh readUInt16LE];
+
+				off_t dataoffset=[fh offsetInFile]+localnamelength+localextralength;
+
+				NSData *namedata=nil;
+				if(localnamelength) namedata=[fh readDataOfLength:localnamelength];
+
+				NSDictionary *extradict=nil;
+				@try {
+					if(localextralength) extradict=[self parseZipExtraWithLength:localextralength nameData:namedata
+					uncompressedSizePointer:&cdr.uncompsize compressedSizePointer:&cdr.compsize];
+				} @catch(id e) {
+					[self setObject:[NSNumber numberWithBool:YES] forPropertyKey:XADIsCorruptedKey];
+					NSLog(@"Error parsing Zip extra fields: %@",e);
+				}
+
+				// TODO: Consider using CDR struct
+				[self addZipEntryWithSystem:cdr.system
+							 extractVersion:cdr.extractversion
+									  flags:cdr.flags
+						  compressionMethod:cdr.compressionmethod
+									   date:cdr.date crc:cdr.crc
+								  localDate:localdate
+							 compressedSize:cdr.compsize
+						   uncompressedSize:cdr.uncompsize
+					 extendedFileAttributes:cdr.extfileattrib
+							extraDictionary:extradict
+								 dataOffset:dataoffset
+								   nameData:namedata
+								commentData:commentdata
+								isLastEntry:i==numentries-1];
+			}
+			else
+			{
+				[self setObject:[NSNumber numberWithBool:YES] forPropertyKey:XADIsCorruptedKey];
+			}
+
+			[fh seekToFileOffset:next];
 		}
-		else [self setObject:[NSNumber numberWithBool:YES] forPropertyKey:XADIsCorruptedKey];
-
-		[fh seekToFileOffset:next];
-
-		[pool release];
+		@finally
+		{
+			[pool release];
+		}
 	}
 }
 
@@ -448,7 +469,7 @@
 
 		uint32_t localid;
 		@try { localid=[fh readID]; }
-		@catch(id e) { break; }
+		@catch(id e) { [pool release]; break; }
 
 		switch(localid)
 		{

--- a/XADZipParser.m
+++ b/XADZipParser.m
@@ -333,12 +333,12 @@
 				if(localnamelength) namedata=[fh readDataOfLength:localnamelength];
 
 				NSDictionary *extradict=nil;
-				@try {
-					if(localextralength) extradict=[self parseZipExtraWithLength:localextralength nameData:namedata
-					uncompressedSizePointer:&cdr.uncompsize compressedSizePointer:&cdr.compsize];
-				} @catch(id e) {
-					[self setObject:[NSNumber numberWithBool:YES] forPropertyKey:XADIsCorruptedKey];
-					NSLog(@"Error parsing Zip extra fields: %@",e);
+				if(localextralength)
+				{
+					extradict=[self parseZipExtraOrNilWithLength:localextralength
+														nameData:namedata
+										 uncompressedSizePointer:&cdr.uncompsize
+										   compressedSizePointer:&cdr.compsize];
 				}
 
 				// TODO: Consider using CDR struct
@@ -468,86 +468,115 @@
 		NSAutoreleasePool *pool=[NSAutoreleasePool new];
 
 		uint32_t localid;
-		@try { localid=[fh readID]; }
-		@catch(id e) { [pool release]; break; }
-
-		switch(localid)
-		{
-			case 0x504b0304: // local record
-			case 0x504b0506: // kludge for strange archives
-			{
-				int extractversion=[fh readUInt16LE];
-				int flags=[fh readUInt16LE];
-				int compressionmethod=[fh readUInt16LE];
-				uint32_t date=[fh readUInt32LE];
-				uint32_t crc=[fh readUInt32LE];
-				off_t compsize=[fh readUInt32LE];
-				off_t uncompsize=[fh readUInt32LE];
-				int namelength=[fh readUInt16LE];
-				int extralength=[fh readUInt16LE];
-
-				off_t dataoffset=[fh offsetInFile]+namelength+extralength;
-
-				NSData *namedata=nil;
-				if(namelength) namedata=[fh readDataOfLength:namelength];
-
-				NSDictionary *extradict=nil;
-				@try {
-					if(extralength) extradict=[self parseZipExtraWithLength:extralength nameData:namedata
-					uncompressedSizePointer:&uncompsize compressedSizePointer:&compsize];
-				} @catch(id e) {
-					[self setObject:[NSNumber numberWithBool:YES] forPropertyKey:XADIsCorruptedKey];
-					NSLog(@"Error parsing Zip extra fields: %@",e);
-				}
-
-				off_t next;
-				if(flags&0x08) // No size or CRC recorded
-				{
-					NSNumber *zip64num=[extradict objectForKey:@"Zip64"];
-
-					[self findEndOfStreamMarkerWithZip64Flag:zip64num&&[zip64num boolValue]
-					uncompressedSizePointer:&uncompsize compressedSizePointer:&compsize
-					CRCPointer:&crc];
-
-					next=[fh offsetInFile];
-				}
-				else
-				{
-					next=dataoffset+compsize;
-				}
-
-				[self addZipEntryWithSystem:-1 extractVersion:extractversion flags:flags
-				compressionMethod:compressionmethod date:date crc:crc localDate:date
-				compressedSize:compsize uncompressedSize:uncompsize extendedFileAttributes:0xffffffff
-				extraDictionary:extradict dataOffset:dataoffset nameData:namedata commentData:nil
-				isLastEntry:NO];
-
-				[fh seekToFileOffset:next];
-			}
-			break;
-
-			case 0x504b0102: // central record - stop scanning
-				[pool release];
-				goto end;
-			break;
-
-			case 0x504b0708: // multi
-			case 0x504b3030: // something strange
-				// Skip these mysterious entries
-				[self findNextEntry];
-			break;
-
-			default:
-				// When encountering unknown data, mark as corrupt and try to recover
-				[self setObject:[NSNumber numberWithBool:YES] forPropertyKey:XADIsCorruptedKey];
-				[self findNextEntry];
+		@try {
+			localid=[fh readID];
+		} @catch(id e) {
+			[pool release];
+			// EOF - stop parsing
 			break;
 		}
 
-		[pool release];
-	}
+		BOOL stopParsing=NO;
+		@try
+		{
+			switch(localid)
+			{
+				case 0x504b0304: // local record
+				case 0x504b0506: // kludge for strange archives
+				{
+					int extractversion=[fh readUInt16LE];
+					int flags=[fh readUInt16LE];
+					int compressionmethod=[fh readUInt16LE];
+					uint32_t date=[fh readUInt32LE];
+					uint32_t crc=[fh readUInt32LE];
+					off_t compsize=[fh readUInt32LE];
+					off_t uncompsize=[fh readUInt32LE];
+					int namelength=[fh readUInt16LE];
+					int extralength=[fh readUInt16LE];
 
-	end:
+					off_t dataoffset=[fh offsetInFile]+namelength+extralength;
+
+					NSData *namedata=nil;
+					if(namelength)
+					{
+						namedata=[fh readDataOfLength:namelength];
+					}
+
+					NSDictionary *extradict=nil;
+					if(extralength)
+					{
+						extradict=[self parseZipExtraOrNilWithLength:extralength
+															nameData:namedata
+											 uncompressedSizePointer:&uncompsize
+											   compressedSizePointer:&compsize];
+					}
+
+					off_t next;
+					if(flags&0x08) // No size or CRC recorded
+					{
+						NSNumber *zip64num=[extradict objectForKey:@"Zip64"];
+
+						[self findEndOfStreamMarkerWithZip64Flag:zip64num&&[zip64num boolValue]
+										 uncompressedSizePointer:&uncompsize
+										   compressedSizePointer:&compsize
+													  CRCPointer:&crc];
+						next=[fh offsetInFile];
+					}
+					else
+					{
+						next=dataoffset+compsize;
+					}
+
+					[self addZipEntryWithSystem:-1
+								 extractVersion:extractversion
+										  flags:flags
+							  compressionMethod:compressionmethod
+										   date:date
+											crc:crc
+									  localDate:date
+								 compressedSize:compsize
+							   uncompressedSize:uncompsize
+						 extendedFileAttributes:0xffffffff
+								extraDictionary:extradict
+									 dataOffset:dataoffset
+									   nameData:namedata
+									commentData:nil
+									isLastEntry:NO];
+
+					[fh seekToFileOffset:next];
+				}
+				break;
+
+				case 0x504b0102: // central directory record found - stop scanning local entries
+				{
+					stopParsing=YES;
+				}
+				break;
+
+				case 0x504b0708: // multi
+				case 0x504b3030: // something strange
+				{
+					// Skip these mysterious entries
+					[self findNextEntry];
+				}
+				break;
+
+				default:
+				{
+					// When encountering unknown data, mark as corrupt and try to recover
+					[self setObject:[NSNumber numberWithBool:YES] forPropertyKey:XADIsCorruptedKey];
+					[self findNextEntry];
+				}
+				break;
+			}
+		}
+		@finally
+		{
+			[pool release];
+		}
+
+		if(stopParsing) break;
+	}
 
 	// Clean up any possible remaining dictionary, since isLastEntry was never set.
 	if(prevdict)
@@ -673,6 +702,24 @@ static int MatchZipEntry(const uint8_t *bytes,int available,off_t offset,void *s
 
 
 
+
+// Returns nil on error; the handle position is left undefined within the extra-field block.
+-(NSDictionary *)parseZipExtraOrNilWithLength:(int)length
+									 nameData:(NSData *)namedata
+					  uncompressedSizePointer:(off_t *)uncompsizeptr
+						compressedSizePointer:(off_t *)compsizeptr
+{
+	@try {
+		return [self parseZipExtraWithLength:length
+									nameData:namedata
+					 uncompressedSizePointer:uncompsizeptr
+					   compressedSizePointer:compsizeptr];
+	} @catch(id e) {
+		[self setObject:[NSNumber numberWithBool:YES] forPropertyKey:XADIsCorruptedKey];
+		NSLog(@"Error parsing Zip extra fields: %@",e);
+		return nil;
+	}
+}
 
 -(NSDictionary *)parseZipExtraWithLength:(int)length nameData:(NSData *)namedata
 uncompressedSizePointer:(off_t *)uncompsizeptr compressedSizePointer:(off_t *)compsizeptr


### PR DESCRIPTION
## Summary
When an exception is thrown during archive parsing, Objective-C skips cleanup code after the throw site — leaving autorelease pools and `malloc`'d buffers unreleased.

This PR identifies and fixes six such cases across `XADZipParser`, `XADCABParser`, `XADUnarchiver`, and `XADCFBFParser` by wrapping affected scopes in `@try`/`@finally` blocks and ensuring buffers are freed on all exit paths.

## Testing
- Existing `XADMasterTests` suite passes with no regressions