### PR TITLE
Fix crash in CFBF parser when entry name length is invalid

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -1,0 +1,30 @@
+name: macOS Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: XCTest (macOS)
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: XADMaster
+
+      - uses: actions/checkout@v4
+        with:
+          repository: MacPaw/universal-detector
+          path: UniversalDetector
+
+      - name: Run tests
+        run: |
+          xcodebuild test \
+            -project XADMaster/XADMaster.xcodeproj \
+            -scheme XADMasterTests \
+            -destination 'platform=macOS' \
+            | xcpretty || exit ${PIPESTATUS[0]}

--- a/XADCFBFParser.m
+++ b/XADCFBFParser.m
@@ -22,6 +22,8 @@
 #import "XADBlockHandle.h"
 #import "NSDateXAD.h"
 
+static const int kCFBFEntryNameMaxSize = 64;
+
 @implementation XADCFBFParser
 
 -(id)init
@@ -134,9 +136,11 @@
 		[self seekToSector:dirsec];
 		for(int i=0;i<secsize;i+=128)
 		{
-			uint8_t name[64];
-			[fh readBytes:64 toBuffer:name];
-			int numnamebytes=[fh readUInt16LE];
+			uint8_t name[kCFBFEntryNameMaxSize];
+			[fh readBytes:kCFBFEntryNameMaxSize toBuffer:name];
+			// The name field in a CFBF directory entry is always kCFBFEntryNameMaxSize bytes,
+			// but the stored length may exceed this in malformed files.
+			int numnamebytes=[self sanitizedNameLength:[fh readUInt16LE] fromBuffer:name];
 			int type=[fh readUInt8];
 			int black=[fh readUInt8];
 			uint32_t leftchild=[fh readUInt32LE];
@@ -272,6 +276,19 @@
 
 	uint32_t right=[[entry objectForKey:@"CFBFRightChild"] unsignedIntValue];
 	if(right!=0xffffffff) [self processEntry:right atPath:path entries:entries];
+}
+
+-(int)sanitizedNameLength:(int)numnamebytes fromBuffer:(const uint8_t *)bytes
+{
+	if(numnamebytes<=kCFBFEntryNameMaxSize) return numnamebytes;
+
+	for(int i=0;i<=kCFBFEntryNameMaxSize-2;i+=2)
+	{
+		if(CSUInt16LE(&bytes[i])==0) return i+2;
+	}
+
+	[XADException raiseIllegalDataException];
+	return 0; // unreachable
 }
 
 -(void)seekToSector:(uint32_t)sector

--- a/XADMasterTests/XADCFBFParserTests.m
+++ b/XADMasterTests/XADCFBFParserTests.m
@@ -1,0 +1,120 @@
+/*
+ * XADCFBFParserTests.m
+ *
+ * Copyright (c) 2017-present, MacPaw Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+#import <XCTest/XCTest.h>
+#import "../XADCFBFParser.h"
+
+@interface XADCFBFParser (TestExtensions)
+- (int)sanitizedNameLength:(int)numnamebytes fromBuffer:(const uint8_t *)bytes;
+@end
+
+@interface XADCFBFParserTests : XCTestCase
+@property (nonatomic, strong) XADCFBFParser *parser;
+@end
+
+@implementation XADCFBFParserTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.parser = [[XADCFBFParser alloc] init];
+}
+
+#pragma mark - Valid length (≤ 64) — must pass through unchanged
+
+- (void)testValidLengthIsPassedThrough
+{
+    // "AB\0" in UTF-16LE — 6 bytes including the null terminator
+    uint8_t name[64] = {0};
+    name[0] = 'A'; name[1] = 0x00;
+    name[2] = 'B'; name[3] = 0x00;
+    name[4] = 0x00; name[5] = 0x00;
+
+    XCTAssertEqual([self.parser sanitizedNameLength:6 fromBuffer:name], 6);
+}
+
+- (void)testZeroLengthIsPassedThrough
+{
+    uint8_t name[64] = {0};
+    XCTAssertEqual([self.parser sanitizedNameLength:0 fromBuffer:name], 0);
+}
+
+- (void)testMaxValidLengthIsPassedThrough
+{
+    // 64 is the exact buffer size — still a legal declared value
+    uint8_t name[64] = {0};
+    XCTAssertEqual([self.parser sanitizedNameLength:64 fromBuffer:name], 64);
+}
+
+#pragma mark - Oversized length — fall back to scanning for UTF-16LE null
+
+- (void)testOversizedLengthFindsNullTerminatorMidBuffer
+{
+    // "Root\0" in UTF-16LE: null terminator at bytes 8–9 → recovered length = 10
+    uint8_t name[64] = {0};
+    name[0] = 'R'; name[1] = 0x00;
+    name[2] = 'o'; name[3] = 0x00;
+    name[4] = 'o'; name[5] = 0x00;
+    name[6] = 't'; name[7] = 0x00;
+    name[8] = 0x00; name[9] = 0x00; // null terminator
+
+    // 66 is the exact malformed value from PR #187 (one over the 64-byte limit)
+    XCTAssertEqual([self.parser sanitizedNameLength:66 fromBuffer:name], 10);
+}
+
+- (void)testOversizedLengthFindsNullAtStart
+{
+    // Buffer starts with a UTF-16LE null word → recovered length = 2
+    uint8_t name[64] = {0};
+    XCTAssertEqual([self.parser sanitizedNameLength:0xFF fromBuffer:name], 2);
+}
+
+- (void)testOversizedLengthFindsNullAtLastValidPosition
+{
+    // Null terminator at bytes 62–63 (last UTF-16LE slot) → recovered length = 64
+    uint8_t name[64];
+    memset(name, 0xAB, sizeof(name));
+    name[62] = 0x00;
+    name[63] = 0x00;
+
+    XCTAssertEqual([self.parser sanitizedNameLength:66 fromBuffer:name], 64);
+}
+
+#pragma mark - Oversized length with no null terminator — must raise
+
+- (void)testOversizedLengthWithNoNullTerminatorRaises
+{
+    // No UTF-16LE null word anywhere in the 64-byte buffer
+    uint8_t name[64];
+    memset(name, 0xAB, sizeof(name));
+
+    XCTAssertThrows([self.parser sanitizedNameLength:66 fromBuffer:name]);
+}
+
+- (void)testMaxOversizedLengthWithNoNullTerminatorRaises
+{
+    uint8_t name[64];
+    memset(name, 0xFF, sizeof(name));
+
+    XCTAssertThrows([self.parser sanitizedNameLength:0xFFFF fromBuffer:name]);
+}
+
+@end


### PR DESCRIPTION
# Summary

The CFBF directory entry format allocates a fixed 64-byte buffer for entry names (UTF-16LE, including null terminator). A separate 2-byte field stores the declared name length — but in malformed files this value can exceed 64, resulting in an out-of-bounds read on a stack-allocated buffer:

```
  Exception Type:  EXC_BAD_ACCESS (KERN_PROTECTION_FAILURE)
  Exception Codes: 0x0000000000000001, 0x00007fff5fbff000

  Thread 0 Crashed:
    0  XADMaster    -[XADCFBFParser decodeFileNameWithBytes:length:]
    1  XADMaster    -[XADCFBFParser parse]
    2  XADMaster    -[XADArchiveParser parseWithoutExceptions]
```

## Changes: 

This PR introduces `sanitizedNameLength:fromBuffer:` which validates the declared length before use. If the length exceeds `kCFBFEntryNameMaxSize`, the buffer is scanned for the actual UTF-16LE null terminator to recover a correct length. If no null terminator is found, `raiseIllegalDataException` is raised — consistent with how this class handles other structural corruption.