### PR TITLE
Fix crash in CFBF parser when sector counts overflow or exceed bounds

### DIFF
--- a/XADCFBFParser.m
+++ b/XADCFBFParser.m
@@ -108,7 +108,15 @@
 		[XADException raiseIllegalDataException];
 	}
 	sectable=malloc((size_t)numsectors*sizeof(uint32_t));
+	if(!sectable)
+	{
+		[XADException raiseOutOfMemoryException];
+	}
 	secvisitedtable=calloc(numsectors,sizeof(bool));
+	if(!secvisitedtable)
+	{
+		[XADException raiseOutOfMemoryException];
+	}
 
 	for(int i=0;i<numtablesecs;i++)
 	{
@@ -144,6 +152,10 @@
 		[XADException raiseIllegalDataException];
 	}
 	minisectable=malloc((size_t)numminisectors*sizeof(uint32_t));
+	if(!minisectable)
+	{
+		[XADException raiseOutOfMemoryException];
+	}
 
 	uint32_t minitablesec=firstminitablesec;
 	for(int i=0;i<numminitablesecs;i++)

--- a/XADCFBFParser.m
+++ b/XADCFBFParser.m
@@ -86,21 +86,29 @@
 	/* Read allocation table through the master allocation table */
 
 	int idspersec=secsize/4;
-	// secsize smaller than 4 truncates to zero on integer division.
-	if(idspersec==0)
+	// Per MS-CFB spec, Sector Shift MUST be 0x0009 (version 3) or 0x000C (version 4),
+	// giving idspersec of 128 or 1024. We do not enforce spec values to preserve
+	// compatibility with non-conformant files. However, idspersec==0 (secsize<4)
+	// and idspersec==1 (secsize==4) must be rejected: the DIFAT traversal below
+	// uses (idspersec-1) as a modulo divisor, which would be zero in those cases.
+	if(idspersec<=1)
 	{
 		[XADException raiseIllegalDataException];
 	}
 
-	int sectorCount;
-	bool sectorCountOverflowed=__builtin_mul_overflow(numtablesecs,idspersec,&sectorCount);
-	if(sectorCountOverflowed)
+	// numtablesecs*idspersec must not overflow int.
+	if(numtablesecs>(uint32_t)(INT_MAX/idspersec))
 	{
 		[XADException raiseIllegalDataException];
 	}
-	numsectors=sectorCount;
-	sectable=malloc(numsectors*sizeof(uint32_t));
-	secvisitedtable=calloc(numsectors*sizeof(bool),1);
+	numsectors=(int)(numtablesecs*(uint32_t)idspersec);
+	// numsectors*sizeof(uint32_t) must not overflow size_t.
+	if((size_t)numsectors>SIZE_MAX/sizeof(uint32_t))
+	{
+		[XADException raiseIllegalDataException];
+	}
+	sectable=malloc((size_t)numsectors*sizeof(uint32_t));
+	secvisitedtable=calloc(numsectors,sizeof(bool));
 
 	for(int i=0;i<numtablesecs;i++)
 	{
@@ -124,14 +132,18 @@
 
 	/* Read short-sector allocation table */
 
-	int miniSectorCount;
-	bool miniSectorCountOverflowed=__builtin_mul_overflow(numminitablesecs,idspersec,&miniSectorCount);
-	if(miniSectorCountOverflowed)
+	// numminitablesecs*idspersec must not overflow int.
+	if(numminitablesecs>(uint32_t)(INT_MAX/idspersec))
 	{
 		[XADException raiseIllegalDataException];
 	}
-	numminisectors=miniSectorCount;
-	minisectable=malloc(numminisectors*sizeof(uint32_t));
+	numminisectors=(int)(numminitablesecs*(uint32_t)idspersec);
+	// numminisectors*sizeof(uint32_t) must not overflow size_t.
+	if((size_t)numminisectors>SIZE_MAX/sizeof(uint32_t))
+	{
+		[XADException raiseIllegalDataException];
+	}
+	minisectable=malloc((size_t)numminisectors*sizeof(uint32_t));
 
 	uint32_t minitablesec=firstminitablesec;
 	for(int i=0;i<numminitablesecs;i++)

--- a/XADCFBFParser.m
+++ b/XADCFBFParser.m
@@ -21,6 +21,7 @@
 #import "XADCFBFParser.h"
 #import "XADBlockHandle.h"
 #import "NSDateXAD.h"
+#import <limits.h>
 
 @implementation XADCFBFParser
 
@@ -56,7 +57,7 @@
 {
 	CSHandle *fh=[self handle];
 
-	// Read header
+	/* Read header */
 
 	[fh skipBytes:30];
 	int secshift=[fh readUInt16LE];
@@ -71,16 +72,33 @@
 	uint32_t firstmastersec=[fh readUInt32LE];
 	/*uint32_t nummastersecs=*/[fh readUInt32LE];
 
+	const int maxSecShift=(int)(sizeof(secsize)*CHAR_BIT)-1;
+	const int maxMiniSecShift=(int)(sizeof(minisecsize)*CHAR_BIT)-1;
+	if(secshift>=maxSecShift || minisecshift>=maxMiniSecShift)
+	{
+		[XADException raiseIllegalDataException];
+	}
+
+	// Shift values are validated above to prevent overflow.
 	secsize=1<<secshift;
 	minisecsize=1<<minisecshift;
 
-
-
-	// Read allocation table through the master allocation table
+	/* Read allocation table through the master allocation table */
 
 	int idspersec=secsize/4;
+	// secsize smaller than 4 truncates to zero on integer division.
+	if(idspersec==0)
+	{
+		[XADException raiseIllegalDataException];
+	}
 
-	numsectors=numtablesecs*idspersec;
+	int sectorCount;
+	bool sectorCountOverflowed=__builtin_mul_overflow(numtablesecs,idspersec,&sectorCount);
+	if(sectorCountOverflowed)
+	{
+		[XADException raiseIllegalDataException];
+	}
+	numsectors=sectorCount;
 	sectable=malloc(numsectors*sizeof(uint32_t));
 	secvisitedtable=calloc(numsectors*sizeof(bool),1);
 
@@ -104,11 +122,15 @@
 		[fh seekToFileOffset:currpos];
 	}
 
+	/* Read short-sector allocation table */
 
-
-	// Read short-sector allocation table
-
-	numminisectors=numminitablesecs*idspersec;
+	int miniSectorCount;
+	bool miniSectorCountOverflowed=__builtin_mul_overflow(numminitablesecs,idspersec,&miniSectorCount);
+	if(miniSectorCountOverflowed)
+	{
+		[XADException raiseIllegalDataException];
+	}
+	numminisectors=miniSectorCount;
 	minisectable=malloc(numminisectors*sizeof(uint32_t));
 
 	uint32_t minitablesec=firstminitablesec;
@@ -119,9 +141,7 @@
 		minitablesec=[self nextSectorAfter:minitablesec];
 	}
 
-
-
-	// Read directory entries
+	/* Read directory entries */
 
 	NSMutableArray *entries=[NSMutableArray array];
 
@@ -129,6 +149,8 @@
 	uint32_t dirsec=firstdirsec;
 	while(dirsec!=0xfffffffe)
 	{
+		// dirsec comes from the file and may exceed the secvisitedtable bounds.
+		if(dirsec>=(uint32_t)numsectors) [XADException raiseIllegalDataException];
 		if(secvisitedtable[dirsec]) [XADException raiseIllegalDataException];
 		secvisitedtable[dirsec]=true;
 		[self seekToSector:dirsec];
@@ -208,9 +230,7 @@
 		dirsec=[self nextSectorAfter:dirsec];
 	}
 
-
-
-	// Resolve directory structure
+	/* Resolve directory structure */
 
 	[self processEntry:rootdirectorynode atPath:[self XADPath] entries:entries];
 }

--- a/XADCFBFParser.m
+++ b/XADCFBFParser.m
@@ -97,7 +97,8 @@
 	}
 
 	// numtablesecs*idspersec must not overflow int.
-	if(numtablesecs>(uint32_t)(INT_MAX/idspersec))
+	// numtablesecs==0 means no FAT sectors, which is invalid.
+	if(numtablesecs==0 || numtablesecs>(uint32_t)(INT_MAX/idspersec))
 	{
 		[XADException raiseIllegalDataException];
 	}
@@ -146,15 +147,20 @@
 		[XADException raiseIllegalDataException];
 	}
 	numminisectors=(int)(numminitablesecs*(uint32_t)idspersec);
-	// numminisectors*sizeof(uint32_t) must not overflow size_t.
-	if((size_t)numminisectors>SIZE_MAX/sizeof(uint32_t))
+	// numminitablesecs==0 is valid for files with no mini-stream.
+	// Skip allocation; malloc(0) may return NULL, which would be misidentified as OOM.
+	if(numminisectors>0)
 	{
-		[XADException raiseIllegalDataException];
-	}
-	minisectable=malloc((size_t)numminisectors*sizeof(uint32_t));
-	if(!minisectable)
-	{
-		[XADException raiseOutOfMemoryException];
+		// numminisectors*sizeof(uint32_t) must not overflow size_t.
+		if((size_t)numminisectors>SIZE_MAX/sizeof(uint32_t))
+		{
+			[XADException raiseIllegalDataException];
+		}
+		minisectable=malloc((size_t)numminisectors*sizeof(uint32_t));
+		if(!minisectable)
+		{
+			[XADException raiseOutOfMemoryException];
+		}
 	}
 
 	uint32_t minitablesec=firstminitablesec;


### PR DESCRIPTION
# Summary 

When parsing CFBF archives, sector counts are computed by multiplying values read directly from the file header. In malformed files these values can overflow a signed `int`, producing an undersized `malloc` buffer. A corrupted `numsectors` also breaks the bounds check in `nextSectorAfter:`, leading to an out-of-bounds read on `sectable`. Additionally, the directory sector index `dirsec` was used to access `secvisitedtable` before any bounds check:
```
    Exception Type:  EXC_BAD_ACCESS (SIGBUS)
    Exception Codes: BUS_NOOP at 0x000000096d883ffd

    Application Specific Information:
    nextSectorAfter: >
    KERN_PROTECTION_FAILURE at 0x96d883ffd

    Thread Crashed:
      0  XADMaster    -[XADCFBFParser parse]
      1  XADMaster    -[XADArchiveParser parseWithoutExceptions]
      2  XADMaster    -[XADSimpleUnarchiver parse]
```

## Key Changes:
* Validate sector shift values against the bit width of their target type before use — a shift value ≥ 31 causes undefined behaviour on a signed `int`.
* Guard sector count and allocation size multiplications against overflow to prevent undersized allocations and a broken bounds check in `nextSectorAfter:`.
* Reject `idspersec ≤ 1` to prevent modulo-by-zero in the DIFAT traversal.
* Check `dirsec` against `numsectors` before accessing `secvisitedtable`.