### PR TITLE
Remove redundant NSData copies in CSHandle

### DIFF
--- a/CSHandle.m
+++ b/CSHandle.m
@@ -249,7 +249,7 @@ CSReadValueImpl(uint32_t,readID,CSUInt32BE)
 	long length=[data length];
 	if(length&&bytes[length-1]=='\r') [data setLength:length-1];
 
-	return [NSData dataWithData:data];
+	return data;
 }
 
 -(NSString *)readLineWithEncoding:(NSStringEncoding)encoding
@@ -283,7 +283,7 @@ CSReadValueImpl(uint32_t,readID,CSUInt32BE)
 	}
 	while(actual!=0);
 
-	return [NSData dataWithData:data];
+	return data;
 }
 
 -(NSData *)readDataOfLength:(int)length


### PR DESCRIPTION
# Summary
`remainingFileContents` and `readLine` in `CSHandle` were building an `NSMutableData` via a convenience constructor (already autoreleased), then copying its contents into a second `NSData` object via `+dataWithData:` before returning. The extra copy served no purpose (`NSMutableData` is a subclass of `NSData` and satisfies the return type directly).

## Changes
* Removed the redundant `+dataWithData:` copy in both methods. The existing `NSMutableData` instance is returned as-is, eliminating an unnecessary allocation and memcpy on every call.
