### PR TITLE
Cache fileSize result in CSFileHandle to avoid redundant fstat calls

### DIFF
--- a/CSFileHandle.h
+++ b/CSFileHandle.h
@@ -32,6 +32,8 @@ extern NSString *CSFileErrorException;
 	FILE *fh;
 	NSString *path;
 	BOOL close;
+	BOOL isReadOnly;
+	off_t cachedFileSize;
 
 	NSLock *multilock;
 	CSFileHandle *fhowner;
@@ -47,6 +49,7 @@ extern NSString *CSFileErrorException;
 
 // Initializers
 -(id)initWithFilePointer:(FILE *)file closeOnDealloc:(BOOL)closeondealloc path:(NSString *)filepath;
+-(id)initWithFilePointer:(FILE *)file closeOnDealloc:(BOOL)closeondealloc path:(NSString *)filepath readOnly:(BOOL)readOnly;
 -(id)initAsCopyOf:(CSFileHandle *)other;
 -(void)dealloc;
 -(void)close;

--- a/CSFileHandle.m
+++ b/CSFileHandle.m
@@ -55,8 +55,13 @@ NSString *CSFileErrorException=@"CSFileErrorException";
 	if(!fileh) [NSException raise:CSCannotOpenFileException
 	format:@"Error attempting to open file \"%@\" in mode \"%@\".",path,modes];
 
-	CSFileHandle *handle=[[[CSFileHandle alloc] initWithFilePointer:fileh closeOnDealloc:YES path:path] autorelease];
-	if(handle) return handle;
+	// Only "rb" is considered read-only; update modes (e.g. "r+b") may modify file size.
+	BOOL readOnly=[modes isEqualToString:@"rb"];
+	CSFileHandle *handle=[[CSFileHandle alloc] initWithFilePointer:fileh
+	                                               closeOnDealloc:YES
+	                                                         path:path
+	                                                     readOnly:readOnly];
+	if(handle) return [handle autorelease];
 
 	fclose(fileh);
 	return nil;
@@ -88,11 +93,18 @@ NSString *CSFileErrorException=@"CSFileErrorException";
 
 -(id)initWithFilePointer:(FILE *)file closeOnDealloc:(BOOL)closeondealloc path:(NSString *)filepath
 {
+	return [self initWithFilePointer:file closeOnDealloc:closeondealloc path:filepath readOnly:NO];
+}
+
+-(id)initWithFilePointer:(FILE *)file closeOnDealloc:(BOOL)closeondealloc path:(NSString *)filepath readOnly:(BOOL)readOnly
+{
 	if(self=[super init])
 	{
 		fh=file;
 		path=[filepath retain];
- 		close=closeondealloc;
+		close=closeondealloc;
+		isReadOnly=readOnly;
+		cachedFileSize=-1;
 		multilock=nil;
 		fhowner=nil;
 	}
@@ -105,7 +117,9 @@ NSString *CSFileErrorException=@"CSFileErrorException";
 	{
 		fh=other->fh;
 		path=[other->path retain];
- 		close=NO;
+		close=NO;
+		isReadOnly=other->isReadOnly;
+		cachedFileSize=other->cachedFileSize;
 		if(other->fhowner) fhowner=[other->fhowner retain];
 		else fhowner=[other retain];
 
@@ -144,6 +158,11 @@ NSString *CSFileErrorException=@"CSFileErrorException";
 
 -(off_t)fileSize
 {
+	if(cachedFileSize>=0)
+	{
+		return cachedFileSize;
+	}
+
 	#if defined(__MINGW32__)
 	struct _stati64 s;
 	if(_fstati64(fileno(fh),&s)) [self _raiseError];
@@ -152,6 +171,10 @@ NSString *CSFileErrorException=@"CSFileErrorException";
 	if(fstat(fileno(fh),&s)) [self _raiseError];
 	#endif
 
+	if(isReadOnly)
+	{
+		cachedFileSize=s.st_size;
+	}
 	return s.st_size;
 }
 


### PR DESCRIPTION
# Summary                                                                                                                                                     
`fileSize` in `CSFileHandle` calls `fstat` on every invocation without caching. Since `atEndOfFile` calls both `offsetInFile` and `fileSize`, parsers that check `atEndOfFile` per entry (such as `XADTarParser`) generate one redundant `fstat` syscall per archive entry. For a TAR archive with thousands of files the file size is fetched repeatedly despite never changing.

## Changes

* added `isReadOnly` and `cachedFileSize` ivars to CSFileHandle.
* added a new designated initializer `initWithFilePointer:closeOnDealloc:path:readOnly:` (the existing initializer delegates to it with `readOnly:NO` for backwards compatibility).
* `fileSize` now returns the cached value on subsequent calls for read-only handles. 
* `initAsCopyOf:` copies both new fields so multi-handle mode inherits the cached value correctly.